### PR TITLE
Limit text-replacement to JSON keys only - VT-57

### DIFF
--- a/weka_upgrade_checker/weka_upgrade_checker.py
+++ b/weka_upgrade_checker/weka_upgrade_checker.py
@@ -1592,7 +1592,7 @@ def client_web_test(results):
 
 def invalid_endpoints(host_name, result, backend_ips):
     result = result.replace(', ]}]', ']}]').replace('container', '"container"').replace(
-        'ip', '"ip"').replace(' {', ' "').replace('},', '",')
+        'ip:', '"ip":').replace(' {', ' "').replace('},', '",')
     result = result.split('\n')[:]
 
     def ip_by_containers(result):


### PR DESCRIPTION
The previous version replaced the JSON string

[{container: {compute0},  ip: [..., "ip-172-31-3-122.ec2.internal", ]}]
[{container: {drives0},   ip: [..., "ip-172-31-3-122.ec2.internal", ]}]
[{container: {frontend0}, ip: [..., "ip-172-16-1-2.ec2.internal", ]}]

with the replacement

['[{"container": "compute0",  "ip": [..., ""ip"-172-16-1-2.ec2.internal"]}]',
 '[{"container": "drives0",   "ip": [..., ""ip"-172-16-1-2.ec2.internal"]}]',
 '[{"container": "frontend0", "ip": [..., ""ip"-172-16-1-2.ec2.internal"]}]']

(Outputs have been edited for clarity and brevity).

Note the quoting of the "ip" key but ALSO the hostname component "ip-172.."

This fix simply limits it to the JSON key by including the colon, as that's not going to appear in a hostname.