### PR TITLE
Vt 184 cst jack

### DIFF
--- a/postinstall/change_failure_domains_to_manual.py
+++ b/postinstall/change_failure_domains_to_manual.py
@@ -348,7 +348,7 @@ def wait_for_container_readiness(host, timeout_secs=180):
             continue
 
 
-def change_failure_domains(s3_drain_timeout, s3_drain_grace, s3_drain_interval, s3_drain_required_checks, force_stop_s3_with_failed_drain_check=False, ssh_identity=None, container_name=None, skip_health_checks=False, skip_prepare_upgrade=False, skip_local_start=False, skip_local_disable=False, wait_unhealthy_timeout_secs=None, skip_s3_drain=False):
+def change_failure_domains(s3_drain_timeout, s3_drain_grace, s3_drain_interval, s3_drain_required_checks, force_stop_s3_with_failed_drain_check=False, ssh_identity=None, container_name=None, skip_health_checks=False, skip_prepare_upgrade=False, skip_local_start=False, skip_local_disable=False, wait_unhealthy_timeout_secs=0, skip_s3_drain=False):
     timestamp = get_timestamp()
     container_filter = ["-F", "container="+container_name] if container_name is not None else []
     hosts = [Host(host_json) for host_json in json.loads(subprocess.check_output(["weka", "cluster", "host", "-b", "-J"] + container_filter))]
@@ -508,7 +508,7 @@ def main():
         wait_unhealthy_timeout_secs=args.wait_unhealthy_timeout_secs,
         skip_s3_drain=args.skip_s3_drain)
 
-def upgrade(s3_drain_timeout, s3_drain_grace, s3_drain_interval, s3_drain_required_checks, force_stop_s3_with_failed_drain_check=False, ssh_identity=None, container_name=None, skip_health_checks=False, wait_unhealthy_timeout_secs=None, skip_s3_drain=False):
+def upgrade(s3_drain_timeout, s3_drain_grace, s3_drain_interval, s3_drain_required_checks, force_stop_s3_with_failed_drain_check=False, ssh_identity=None, container_name=None, skip_health_checks=False, wait_unhealthy_timeout_secs=0, skip_s3_drain=False):
     wait_start = datetime.now()
     changed_hosts, skipped_hosts = change_failure_domains(
         s3_drain_timeout, s3_drain_grace, s3_drain_interval, s3_drain_required_checks, force_stop_s3_with_failed_drain_check, ssh_identity, container_name, skip_health_checks, wait_unhealthy_timeout_secs, skip_s3_drain)

--- a/weka_upgrade_checker/weka_upgrade_checker.py
+++ b/weka_upgrade_checker/weka_upgrade_checker.py
@@ -1811,6 +1811,11 @@ def backend_host_checks(backend_hosts, ssh_bk_hosts, weka_version, check_version
         else:
             data_dir_check(host_name, result)
 
+    INFO("CHECKING FOR REQUIRED CPU INSTRUCTION SET ON BACKENDS")
+    results = parallel_execution(ssh_bk_hosts, ['grep -q "\<avx2\>" /proc/cpuinfo'], use_check_output=False, use_call=True, ssh_identity=ssh_identity)
+    for host_name, result in results:
+        if result != 0:
+            WARN(f"Host: {host_name} does not have the required CPU features provided by x86_64-v3")
 
 # CLIENT CHECKES
 def client_hosts_checks(weka_version, ssh_cl_hosts, check_version, ssh_identity):
@@ -1887,6 +1892,12 @@ def client_hosts_checks(weka_version, ssh_cl_hosts, check_version, ssh_identity)
         if result is None:
             WARN(
                 f"Unable to determine Host: {host_name} weka container status")
+
+    INFO("CHECKING FOR REQUIRED CPU INSTRUCTION SET ON CLIENTS")
+    results = parallel_execution(ssh_cl_hosts, ['grep -q "\<avx2\>" /proc/cpuinfo'], use_check_output=False, use_call=True, ssh_identity=ssh_identity)
+    for host_name, result in results:
+        if result != 0:
+            WARN(f"Host: {host_name} does not have the required CPU features provided by x86_64-v3")
 
     if results != []:
         weka_container_status(results, weka_version)


### PR DESCRIPTION
    VT-184: Add checking to ensure that CPUs support x86_64-v3 instruction set
    
    As per recent core base compiler changes, older Sandy Bridge or Ivy Bridge
    CPUs are no longer supported. We need at least Haswell's x86_64-v3 options.
    
    This code checks for the implied existence of x86_64-v3 by checking for
    the existence of avx2 in /proc/cpuinfo as a reasonable proxy for the
    presence of the complete instruction set.
