### PR TITLE
Adding check to validate that Numa is set to NPS4

### DIFF
--- a/install/scripts.d/default/201_checknps4.sh
+++ b/install/scripts.d/default/201_checknps4.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+DESCRIPTION="Check if NUMA is set to NPS4"
+SCRIPT_TYPE="parallel"
+
+nps_value=$(lscpu | awk '/^NUMA node\(s):/ { print $3 }')
+
+if [ "$nps_value" -eq "4" ]; then
+    echo "NUMA is set to NPS4 on $HOSTNAME"
+    ret="0"
+else
+    echo "NUMA is not set to NPS4 on $HOSTNAME (current value $nps_value)"
+    ret="1"
+fi
+
+exit $ret


### PR DESCRIPTION
```
bash -x scripts.d/default/201_checknps4.sh
+ DESCRIPTION='Check if NUMA is set to NPS4'
+ SCRIPT_TYPE=parallel
++ lscpu
++ awk '/^NUMA node\(s):/ { print $3 }'
+ nps_value=4
+ '[' 4 -eq 4 ']'
+ echo 'NUMA is set to NPS4 on s10sn0001.us-smf12.baremetal.cssp.tzla.net'
NUMA is set to NPS4 on s10sn0001.us-smf12.baremetal.cssp.tzla.net
+ ret=0
+ exit 0
```