### PR TITLE
Update 'resources_generator.py' script from Wekapp.

### DIFF
--- a/install/resources_generator.py
+++ b/install/resources_generator.py
@@ -33,8 +33,8 @@ IS_SINGLE_CORE = int(os.popen("nproc").read().strip()) == 1  # TODO: validate co
 # Memory consts (from hugepages.d):
 WEKANODE_BUCKET_PROCESS_MEMORY = 3.9 * GiB
 WEKANODE_SSD_PROCESS_MEMORY = 2.2 * GiB
-WEKANODE_FRONTEND_PROCESS_MEMORY = 2.5 * GiB
-WEKANODE_MANAGER_PROCESS_MEMORY = 3.1 * GiB
+WEKANODE_FRONTEND_PROCESS_MEMORY = 2.3 * GiB
+WEKANODE_MANAGER_PROCESS_MEMORY = 2.1 * GiB
 
 OVERHEAD_PER_MBUF = 202 + 72 + 16 + 30  # GenericBaseBlock + QueuedBlock + Cache entries + unknown respectively
 MBUFS_IN_HUGEPAGE = 481  # max N such that `align4K(256*N) + 4096*N <= 2MB
@@ -439,8 +439,6 @@ class ResourcesGenerator:
                                  "For allowing rotating disks - please add '--allow-rotational' as well")
         parser.add_argument("--allow-rotational", action='store_true',
                             help="Detect rotational disks")
-        parser.add_argument("--allocate-nics-exclusively", action='store_true',
-                            help="Set one unique net device per each io node, relevant when using virtual functions (VMware, KVM etc.)")
         parser.add_argument("--core-ids", default=[], nargs='+', type=int,
                             help="Specify manually which CPUs to allocate for weka nodes")
         parser.add_argument("--compute-core-ids", default=[], nargs='+', type=int,
@@ -466,8 +464,25 @@ class ResourcesGenerator:
         parser.add_argument("--use-only-nic-identifier", action='store_true', dest='use_only_nic_identifier',
                             help="use only the nic identifier when allocating the nics")
 
+        # Create a mutually exclusive group
+        group = parser.add_mutually_exclusive_group()
+
+        group.add_argument(
+            "--allocate-nics-exclusively", action='store_true',
+            help="Set one unique net device per each io node, relevant when using virtual functions (VMware, KVM etc.)")
+
+        group.add_argument(
+            "--dont-allocate-nics-exclusively", action='store_true',
+            help="Do not set one unique net device per each IO node"
+        )
+
         self.args = parser.parse_args()
-        self.exclusive_nics_policy = is_cloud_env() or self.args.allocate_nics_exclusively
+
+        if self.args.dont_allocate_nics_exclusively:
+            self.exclusive_nics_policy = False
+        else:
+            self.exclusive_nics_policy = is_cloud_env() or self.args.allocate_nics_exclusively
+
         _validate_net_dev()
         _verify_core_ids(self.args.drive_core_ids + self.args.compute_core_ids + self.args.frontend_core_ids)
         _verify_core_ids(self.args.core_ids)
@@ -586,7 +601,7 @@ class ResourcesGenerator:
                 quit(1)
 
         def _validate_netmask(netmask):
-            if not netmask.isdecimal() or int(netmask) not in range(0, 33):
+            if not netmask.isdecimal() or int(netmask) not in range(0, 129):
                 logger.error("Invalid value for netmask: %s", netmask)
                 quit(1)
             return netmask
@@ -1063,4 +1078,3 @@ class ResourcesGenerator:
 if __name__ == '__main__':
     rg = ResourcesGenerator()
     rg.generate()
-


### PR DESCRIPTION
1. f26cc852dc03446dcb7478863c27f69089575c08 - fix test TestVerifyNodesResidentMemorySizesEstimation and consts (WEKAPP-363827)
2. 68b3bcbc8cba44f2b29e62c4d1b1c02e8932cebd -  Extend netmask validation to support IPv6. New flag `--dont-allocate-nics-exclusively` used as a workaround to missing '--udp' flag (cloud)