### PR TITLE
Fix Issue 352: weka_upgrade_checker reports an extra alert

### DIFF
--- a/weka_upgrade_checker/weka_upgrade_checker.py
+++ b/weka_upgrade_checker/weka_upgrade_checker.py
@@ -413,6 +413,7 @@ def weka_cluster_checks():
     weka_alerts = (
         subprocess.check_output(["weka", "alerts", "--no-header"])
         .decode("utf-8")
+        .rstrip("\n")
         .split("\n")
     )
     if len(weka_alerts) == 0:


### PR DESCRIPTION
  We need to strip off a trailing "\n" from the alert command
  output before counting the alerts