### PR TITLE
wekadestroy: Add --force to `weka local stop`

### DIFF
--- a/install/wekadestroy
+++ b/install/wekadestroy
@@ -100,7 +100,7 @@ unmount_all_weka_fs_all_hosts() {
 }
 
 stop_weka() {
-	$ssh "$1" 'sudo weka local stop'
+	$ssh "$1" 'sudo weka local stop --force'
 }
 
 remove_weka_containers() {


### PR DESCRIPTION
In WEKA 4.4, `weka local stop` gracefully stops containers, which is not necessary for the purpose of wekadestroy (predominantly used during deployment for iterative testing or to deploy different configurations).

`--force` skips checks for active mounts in older WEKA versions. It adds non-graceful shutdown of containers in 4.4.

Given that we unmount file systems on WEKA backends in `wekadestroy`, simply using `--force` globally is acceptable. Additionally, if I recall correctly, clients we forget to unmount should automatically remount file systems on a redeployed (new) cluster.