### PR TITLE
Cst jack support checking kernel args

### DIFF
--- a/weka_upgrade_checker/known_issues.json
+++ b/weka_upgrade_checker/known_issues.json
@@ -1,4 +1,15 @@
 {
+    "4.4.7.89": [
+        {
+            "description": "IOMMU enabled in passthrough mode",
+            "related_protocols": [],
+            "link_types": [],
+            "problematic_kernel_arguments": [ "iommu=pt" ],
+            "internal_reference": "WEKAPP-513581",
+            "version_from": [],
+            "obj_store": false
+        }
+    ],
     "4.4.1-2": [
         {
             "description": "Will need to backup and remove WEKA SMB configuration before upgrading to 4.4.1-2 or higher",

--- a/weka_upgrade_checker/known_issues.json
+++ b/weka_upgrade_checker/known_issues.json
@@ -4,6 +4,8 @@
             "description": "Will need to backup and remove WEKA SMB configuration before upgrading to 4.4.1-2 or higher",
             "related_protocols": ["smb"],
             "link_types": [],
+            "problematic_kernel_arguments": [],
+            "internal_reference": "",
             "version_from": ["4.4.1"],
             "obj_store": false
         }
@@ -13,6 +15,8 @@
             "description": "If the weka-agent init.d or systemd unit files have been modified, revert all changes and restore them to their original state.",
             "related_protocols": [],
             "link_types": [],
+            "problematic_kernel_arguments": [],
+            "internal_reference": "",
             "version_from": [],
             "obj_store": false
         }
@@ -22,6 +26,8 @@
             "description": "If the weka-agent init.d or systemd unit files have been modified, revert all changes and restore them to their original state.",
             "related_protocols": [],
             "link_types": [],
+            "problematic_kernel_arguments": [],
+            "internal_reference": "",
             "version_from": [],
             "obj_store": false
         }
@@ -31,6 +37,8 @@
             "description": "If the weka-agent init.d or systemd unit files have been modified, revert all changes and restore them to their original state.",
             "related_protocols": [],
             "link_types": [],
+            "problematic_kernel_arguments": [],
+            "internal_reference": "",
             "version_from": [],
             "obj_store": false
         }
@@ -40,6 +48,8 @@
             "description": "If the weka-agent init.d or systemd unit files have been modified, revert all changes and restore them to their original state.",
             "related_protocols": [],
             "link_types": [],
+            "problematic_kernel_arguments": [],
+            "internal_reference": "",
             "version_from": [],
             "obj_store": false
         }
@@ -49,6 +59,8 @@
             "description": "If the weka-agent init.d or systemd unit files have been modified, revert all changes and restore them to their original state.",
             "related_protocols": [],
             "link_types": [],
+            "problematic_kernel_arguments": [],
+            "internal_reference": "",
             "version_from": [],
             "obj_store": false
         }
@@ -58,6 +70,8 @@
             "description": "",
             "related_protocols": [],
             "link_types": [],
+            "problematic_kernel_arguments": [],
+            "internal_reference": "",
             "version_from": [],
             "obj_store": false
         }

--- a/weka_upgrade_checker/weka_upgrade_checker.py
+++ b/weka_upgrade_checker/weka_upgrade_checker.py
@@ -2561,11 +2561,11 @@ def ssh_check(host_name, result, ssh_bk_hosts):
     passwordless_ssh = result
     if passwordless_ssh != 0:
         BAD(
-            f'Password SSH not configured on host: {host_name}, will exclude from checks'
+            f'Passwordless SSH not configured on host: {host_name}, will exclude from checks'
         )
         ssh_bk_hosts = [x for x in ssh_bk_hosts if x["name"] != host_name]
     else:
-        GOOD(f'Password SSH configured on host: {host_name}')
+        GOOD(f'Passwordless SSH configured on host: {host_name}')
 
     return ssh_bk_hosts
 
@@ -3266,7 +3266,7 @@ def backend_host_checks(
             WARN(f"Unable to determine weka mounts on Host: {host_name}")
 
     if len(ssh_bk_hosts) == 0:
-        BAD(f'Unable to proceed, Password SSH not configured on any host')
+        BAD(f'Unable to proceed, passwordless SSH not configured on any host')
         sys.exit(1)
 
     if V(weka_version) >= V("3.12"):
@@ -3737,7 +3737,7 @@ def client_hosts_checks(weka_version, ssh_cl_hosts, check_version, ssh_identity)
 
     ssh_cl_hosts = [host_dict["name"] for host_dict in ssh_cl_hosts_dict]
     if len(ssh_cl_hosts) == 0:
-        BAD(f'Unable to proceed, Password SSH not configured on any host')
+        BAD(f'Unable to proceed, passwordless SSH not configured on any host')
         sys.exit(1)
 
     if V(weka_version) >= V("3.12"):

--- a/weka_upgrade_checker/weka_upgrade_checker.py
+++ b/weka_upgrade_checker/weka_upgrade_checker.py
@@ -49,6 +49,8 @@ else:
 pg_version = "1.4.13"
 
 
+known_issues_file = "known_issues.json"
+
 log_file_path = os.path.abspath("./weka_upgrade_checker.log")
 
 logging.basicConfig(
@@ -3901,7 +3903,6 @@ def cluster_summary():
 
 def check_known_issues(
     upgrade_hops,
-    known_issues_file,
     s3_enabled,
     weka_nfs,
     weka_smb,
@@ -4089,7 +4090,6 @@ def target_version_check(
             # Check for known issues with protocol filtering
             check_known_issues(
                 upgrade_hops,
-                "known_issues.json",
                 s3_enabled,
                 weka_nfs,
                 weka_smb,


### PR DESCRIPTION
We need to check backends' (at least) kernel arguments.
This code:

- adds a generic framework for kernel argument checking
- adds a couple of typo fixes
- adds the specific iommu=pt check for target version 4.4.7.89