### PR TITLE
Sean rolling reboots

### DIFF
--- a/utils/rolling_reboots.sh
+++ b/utils/rolling_reboots.sh
@@ -167,7 +167,7 @@ for host in "${HOSTS[@]}"; do
 	if [[ "${host%%.*}" == "${local_hostname%%.*}" ]]; then log "SKIPPING:   $host due to it being localhost"; skipped=$((skipped + 1)); continue; fi
 	#Skip if commented out
 	if [[ $host == \#* ]]; then log "SKIPPING:   $host due to leading #"; skipped=$((skipped + 1)); continue; fi
-	if ! ssh -l "$SSH_USER" -o ConnectTimeout=5 -o BatchMode=yes "$host" "exit" 2>/dev/null;then
+	if ! ssh -l "$SSH_USER" -o ConnectTimeout=5 -o BatchMode=yes -o StrictHostKeyChecking=accept-new "$host" "exit" 2>/dev/null;then
 		log "ERROR:      $host is offline"
 		if [ "$SKIP_IF_OFFLINE" != true ];then
 			log "FATAL:      Host is offline, set SKIP_IF_OFFLINE in the configuration section to allow continuing in this case"


### PR DESCRIPTION
Added a utility script to go through and perform rolling reboots, optionally draining S3.
Includes option to do PCIe remove and rescan for drives that fail to come back up after reboot.
Waits for WEKA cluster status to be OK prior to continuing reboots.
Testing on 4.2.11 and 4.4.8.53, with and without S3.