### PR TITLE
Sync preinstall/sbr-config to upstream v1.5.0

### DIFF
--- a/preinstall/sbr-config/README.md
+++ b/preinstall/sbr-config/README.md
@@ -56,6 +56,9 @@ Options:
 
   --exclude IFACE         Exclude interface from SBR (repeatable)
   --include IFACE         Only configure these interfaces (repeatable)
+  --rule-priority PRIO    Base priority for new IP rules (default: 10000,
+                          stepping 10 per rule; must be 1-32765). Use the
+                          same value on every run of a given system.
 
   --backup-file PATH      Specific backup file for --rollback
   --log-file PATH         Log file (default: /var/log/sbr-config.log)

--- a/preinstall/sbr-config/README.md
+++ b/preinstall/sbr-config/README.md
@@ -101,7 +101,9 @@ Each proposed change includes:
 
 ### Rollback (`--rollback`)
 
-Restores the system to its state before the last configuration:
+Restores the configuration that was running when the backup was taken:
+SBR rules, routes, rt_tables entries, and persistence files are put back
+exactly as they were, and anything added since is removed.
 
 ```bash
 # Restore from latest backup
@@ -154,9 +156,10 @@ For non-default interfaces, the tool tries multiple strategies to find the gatew
 2. DHCP lease files (`/var/lib/dhclient/`, `/var/lib/dhcp/`, etc.)
 3. NetworkManager (`nmcli`)
 4. systemd-networkd config files
-5. Common `.1` address heuristic
 
-If no gateway can be detected, the interface is skipped with a warning.
+If no gateway can be detected, the interface is configured without a
+default route in its table (subnet-only routing, normal for non-routable
+storage or interconnect networks).
 
 ## Backups
 
@@ -165,9 +168,13 @@ State backups are stored in `/var/lib/sbr-config/backups/` as JSON files contain
 - Routing table entries
 - All routes and rules
 - Sysctl values
-- Raw file contents for exact restoration
+- Raw file contents for exact restoration (rt_tables and every persistence file)
 
-A `latest.json` symlink always points to the most recent backup.
+Backups are named `state_<date>_<time>.json` and never overwritten (a
+counter suffix is added if two are saved in the same second), so any of
+them can be referenced later with `--backup-file`. A `latest.json` symlink
+always points to the most recent backup, and the 10 most recent backups
+are kept.
 
 ## Interface Filtering
 

--- a/preinstall/sbr-config/README.md
+++ b/preinstall/sbr-config/README.md
@@ -124,7 +124,7 @@ For each non-default network interface, `sbr-config` creates:
 | Routing table | `100 sbr_eth1` in `/etc/iproute2/rt_tables` | Dedicated table for eth1's routes |
 | Subnet route | `ip route add 10.0.2.0/24 dev eth1 table sbr_eth1` | Reach the local network segment |
 | Default route | `ip route add default via 10.0.2.1 dev eth1 table sbr_eth1` | Reach remote networks via eth1's gateway |
-| Policy rule | `ip rule add from 10.0.2.50 table sbr_eth1` | Direct eth1's traffic to its table |
+| Policy rule | `ip rule add from 10.0.2.50 table sbr_eth1 priority 10000` | Direct eth1's traffic to its table (priorities start at 10000, leaving lower values free for VPN/firewall/admin rules that should take precedence) |
 
 ### Sysctl Settings
 

--- a/preinstall/sbr-config/README.md
+++ b/preinstall/sbr-config/README.md
@@ -131,7 +131,7 @@ For each non-default network interface, `sbr-config` creates:
 | Setting | Value | Purpose |
 |---------|-------|---------|
 | `net.ipv4.conf.all.rp_filter` | `2` | Loose reverse path filtering (required for SBR) |
-| `net.ipv4.conf.<iface>.rp_filter` | `2` | Per-interface loose RP filter (runtime only, see below) |
+| `net.ipv4.conf.<iface>.rp_filter` | `2` | Per-interface loose RP filter (runtime only, and only when `conf.all` is not already loose -- the kernel uses `max(all, iface)`) |
 | `net.ipv4.conf.all.arp_filter` | `1` | Prevent ARP flux on multi-NIC systems |
 | `net.ipv4.conf.all.arp_announce` | `2` | Use best local address for ARP |
 
@@ -141,10 +141,10 @@ With `--persist`, the tool writes configuration appropriate for the detected net
 
 | Network Manager | Persistence Method |
 |----------------|--------------------|
-| **NetworkManager** | Dispatcher script in `/etc/NetworkManager/dispatcher.d/` |
-| **systemd-networkd** | `.network` files in `/etc/systemd/network/` |
-| **ifupdown** | `post-up`/`pre-down` in `/etc/network/interfaces` |
-| **Netplan** | YAML in `/etc/netplan/90-sbr-config.yaml` |
+| **NetworkManager** | Dispatcher script in `/etc/NetworkManager/dispatcher.d/` (fires only for NM-managed devices; unmanaged interfaces are warned about) |
+| **systemd-networkd** | Drop-in `<applied-file>.network.d/50-sbr.conf` merged into the `.network` file networkd already applies to each link (networkd applies exactly one `.network` file per link, so a standalone file would shadow or be shadowed by the real config) |
+| **ifupdown** | `post-up`/`pre-down` added to the interface's existing stanza in `/etc/network/interfaces` or a sourced `interfaces.d` file |
+| **Netplan** | YAML in `/etc/netplan/90-sbr-config.yaml`, merged with any routes/routing-policy other netplan files define for the same interfaces (netplan replaces list values wholesale across files) |
 
 Global sysctl settings are persisted to `/etc/sysctl.d/90-sbr-config.conf` regardless of network manager. Per-interface `rp_filter` keys are set at runtime only and deliberately never persisted: sysctl.d is applied early at boot, before late-binding drivers (e.g. Mellanox/IPoIB `ib*`) create their interfaces, so persisted per-interface keys log errors on every boot. They are also unnecessary -- `conf.default.rp_filter=2` is inherited by interfaces created later, and the kernel evaluates `max(all, iface)`, so `conf.all.rp_filter=2` already makes loose mode effective.
 

--- a/preinstall/sbr-config/README.md
+++ b/preinstall/sbr-config/README.md
@@ -131,7 +131,7 @@ For each non-default network interface, `sbr-config` creates:
 | Setting | Value | Purpose |
 |---------|-------|---------|
 | `net.ipv4.conf.all.rp_filter` | `2` | Loose reverse path filtering (required for SBR) |
-| `net.ipv4.conf.<iface>.rp_filter` | `2` | Per-interface loose RP filter |
+| `net.ipv4.conf.<iface>.rp_filter` | `2` | Per-interface loose RP filter (runtime only, see below) |
 | `net.ipv4.conf.all.arp_filter` | `1` | Prevent ARP flux on multi-NIC systems |
 | `net.ipv4.conf.all.arp_announce` | `2` | Use best local address for ARP |
 
@@ -146,7 +146,7 @@ With `--persist`, the tool writes configuration appropriate for the detected net
 | **ifupdown** | `post-up`/`pre-down` in `/etc/network/interfaces` |
 | **Netplan** | YAML in `/etc/netplan/90-sbr-config.yaml` |
 
-Sysctl settings are persisted to `/etc/sysctl.d/90-sbr-config.conf` regardless of network manager.
+Global sysctl settings are persisted to `/etc/sysctl.d/90-sbr-config.conf` regardless of network manager. Per-interface `rp_filter` keys are set at runtime only and deliberately never persisted: sysctl.d is applied early at boot, before late-binding drivers (e.g. Mellanox/IPoIB `ib*`) create their interfaces, so persisted per-interface keys log errors on every boot. They are also unnecessary -- `conf.default.rp_filter=2` is inherited by interfaces created later, and the kernel evaluates `max(all, iface)`, so `conf.all.rp_filter=2` already makes loose mode effective.
 
 ## Gateway Detection
 

--- a/preinstall/sbr-config/sbr-config.sh
+++ b/preinstall/sbr-config/sbr-config.sh
@@ -48,7 +48,7 @@ for candidate in python3 python; do
     if command -v "$candidate" &>/dev/null; then
         major=$("$candidate" -c "import sys; print(sys.version_info.major)" 2>/dev/null) || continue
         minor=$("$candidate" -c "import sys; print(sys.version_info.minor)" 2>/dev/null) || continue
-        if [[ "$major" -ge "$MIN_PYTHON_MAJOR" ]] && [[ "$minor" -ge "$MIN_PYTHON_MINOR" ]]; then
+        if [[ "$major" -gt "$MIN_PYTHON_MAJOR" ]] || { [[ "$major" -eq "$MIN_PYTHON_MAJOR" ]] && [[ "$minor" -ge "$MIN_PYTHON_MINOR" ]]; }; then
             PYTHON="$candidate"
             break
         fi
@@ -149,7 +149,7 @@ for arg in "$@"; do
                 check_warn "/etc/iproute2/rt_tables: not writable (need root)"
             fi
         else
-            check_fail "/etc/iproute2/rt_tables: not found"
+            check_warn "/etc/iproute2/rt_tables: not found (will be created during --configure)"
         fi
 
         # Multiple interfaces

--- a/preinstall/sbr-config/sbr_config/__init__.py
+++ b/preinstall/sbr-config/sbr_config/__init__.py
@@ -1,3 +1,3 @@
 """sbr-config: Linux source-based routing configuration tool."""
 
-__version__ = "1.2.0"
+__version__ = "1.2.1"

--- a/preinstall/sbr-config/sbr_config/__init__.py
+++ b/preinstall/sbr-config/sbr_config/__init__.py
@@ -1,3 +1,3 @@
 """sbr-config: Linux source-based routing configuration tool."""
 
-__version__ = "1.4.0"
+__version__ = "1.5.0"

--- a/preinstall/sbr-config/sbr_config/__init__.py
+++ b/preinstall/sbr-config/sbr_config/__init__.py
@@ -1,3 +1,3 @@
 """sbr-config: Linux source-based routing configuration tool."""
 
-__version__ = "1.1.0"
+__version__ = "1.2.0"

--- a/preinstall/sbr-config/sbr_config/__init__.py
+++ b/preinstall/sbr-config/sbr_config/__init__.py
@@ -1,3 +1,3 @@
 """sbr-config: Linux source-based routing configuration tool."""
 
-__version__ = "1.3.0"
+__version__ = "1.3.1"

--- a/preinstall/sbr-config/sbr_config/__init__.py
+++ b/preinstall/sbr-config/sbr_config/__init__.py
@@ -1,3 +1,3 @@
 """sbr-config: Linux source-based routing configuration tool."""
 
-__version__ = "1.2.1"
+__version__ = "1.3.0"

--- a/preinstall/sbr-config/sbr_config/__init__.py
+++ b/preinstall/sbr-config/sbr_config/__init__.py
@@ -1,3 +1,3 @@
 """sbr-config: Linux source-based routing configuration tool."""
 
-__version__ = "1.3.1"
+__version__ = "1.4.0"

--- a/preinstall/sbr-config/sbr_config/cli.py
+++ b/preinstall/sbr-config/sbr_config/cli.py
@@ -33,6 +33,7 @@ Short flags:
   -t  --confirm-timeout   -x  --exclude          -i  --include
   -b  --backup-file       -l  --log-file         -C  --no-color
   -v  --verbose           -q  --quiet            -P  --no-persist
+  -R  --rule-priority
 
 Examples:
   sbr-config -V                      Check current SBR state
@@ -123,6 +124,20 @@ Safety:
         help="Only configure these interfaces (repeatable)",
     )
     parser.add_argument(
+        "-R", "--rule-priority",
+        type=int,
+        default=None,
+        metavar="PRIO",
+        help=(
+            "Base priority for new IP rules (default: 10000, stepping 10 "
+            "per rule). Lower values evaluate first; keep values below "
+            "10000 free for VPN/firewall/admin rules that should take "
+            "precedence. Must be 1-32765 (rules at 32766+ never fire when "
+            "the main table holds a default route). Use the same value on "
+            "every run of a given system."
+        ),
+    )
+    parser.add_argument(
         "-b", "--backup-file",
         metavar="PATH",
         help="Specific backup file to restore from (with -r/--rollback)",
@@ -180,6 +195,15 @@ def main(argv: List[str] = None) -> int:
             "one of the arguments -V/--validate -c/--configure -r/--rollback "
             "-p/--check-prereqs is required"
         )
+
+    if args.rule_priority is not None:
+        from .constants import RULE_PRIORITY_MAX
+        if not 1 <= args.rule_priority <= RULE_PRIORITY_MAX:
+            parser.error(
+                f"--rule-priority must be between 1 and {RULE_PRIORITY_MAX} "
+                f"(rules at 32766 or above sit after the main table lookup "
+                f"and never fire when main holds a default route)"
+            )
 
     # Setup
     setup_logging(args.log_file, args.verbose)
@@ -286,7 +310,9 @@ def _do_configure(args: argparse.Namespace, out: Output) -> int:
 
         # Plan changes
         out.header("Proposed Changes")
-        changes = plan_changes(state, results)
+        changes = plan_changes(
+            state, results, rule_priority_start=args.rule_priority
+        )
 
         if not changes:
             out.info("No actionable changes could be planned.")

--- a/preinstall/sbr-config/sbr_config/cli.py
+++ b/preinstall/sbr-config/sbr_config/cli.py
@@ -278,16 +278,10 @@ def _do_configure(args: argparse.Namespace, out: Output) -> int:
         if failed == 0:
             out.nl()
             out.info("System is correctly configured for source-based routing.")
-            # Self-heal persistence written by <=1.2.0: per-interface sysctl
-            # keys fail at boot for late-created interfaces (e.g. ib*).
-            if not args.no_persist:
-                from .sysctl import refresh_sysctl_persistence_if_stale
-                if refresh_sysctl_persistence_if_stale():
-                    out.info(
-                        "Refreshed /etc/sysctl.d/90-sbr-config.conf: removed "
-                        "per-interface keys that fail at boot for interfaces "
-                        "created by late driver load (e.g. ib*)."
-                    )
+            # Gated on dry-run: a dry run must never write to disk, and
+            # errors here must not fail a run that needed nothing.
+            if not args.dry_run and not args.no_persist:
+                _heal_persistence(state, out)
             return 0
 
         # Plan changes
@@ -409,8 +403,51 @@ def _do_rollback(args: argparse.Namespace, out: Output) -> int:
 
 
 # ---------------------------------------------------------------------------
-# Persistence helper
+# Persistence helpers
 # ---------------------------------------------------------------------------
+
+def _heal_persistence(state, out: Output) -> None:
+    """Repair persistence drift on an already-correct system.
+
+    Rewrites the managed sysctl.d file when it differs from the desired
+    content (e.g. per-interface keys from <=1.2.0 that fail at boot for
+    late-created interfaces), creates it if SBR is active but the file is
+    missing, and warns when no interface-level persistence exists at all.
+    Failures downgrade to warnings -- this run needed no changes and must
+    not fail because /etc is read-only or full.
+    """
+    from .constants import TABLE_NAME_PREFIX
+    from .persistence import interface_persistence_exists
+    from .sysctl import refresh_sysctl_persistence
+
+    has_sbr = any(
+        rt.name.startswith(TABLE_NAME_PREFIX) for rt in state.routing_tables
+    )
+    try:
+        action = refresh_sysctl_persistence(ensure=has_sbr)
+    except (SbrConfigError, OSError) as e:
+        out.warning(f"Could not refresh sysctl persistence: {e}")
+        return
+    if action == "rewritten":
+        out.info(
+            "Refreshed /etc/sysctl.d/90-sbr-config.conf: replaced stale "
+            "content (e.g. per-interface keys that fail at boot for "
+            "late-created interfaces such as ib*)."
+        )
+    elif action == "created":
+        out.info(
+            "Wrote /etc/sysctl.d/90-sbr-config.conf: SBR is active but "
+            "sysctl persistence was missing."
+        )
+
+    if has_sbr and not interface_persistence_exists():
+        out.warning(
+            "SBR runtime configuration is correct but no managed interface "
+            "persistence files were found -- routes and rules may not "
+            "survive a reboot. To re-create persistence, run "
+            "'sbr-config --rollback' followed by 'sbr-config --configure'."
+        )
+
 
 def _write_persistence(
     state,

--- a/preinstall/sbr-config/sbr_config/cli.py
+++ b/preinstall/sbr-config/sbr_config/cli.py
@@ -54,7 +54,10 @@ Safety:
 """,
     )
 
-    mode = parser.add_mutually_exclusive_group(required=True)
+    # Action group is not strictly required at the argparse level so we can
+    # treat bare `--dry-run` as `--configure --dry-run` (the only mode where
+    # dry-run is meaningful).  Enforced manually after parsing.
+    mode = parser.add_mutually_exclusive_group(required=False)
     mode.add_argument(
         "-V", "--validate",
         action="store_true",
@@ -79,7 +82,11 @@ Safety:
     parser.add_argument(
         "-f", "--force",
         action="store_true",
-        help="Skip interactive confirmation (use with -c/--configure)",
+        help=(
+            "Skip all interactive confirmation -- both the pre-apply 'are you sure?' "
+            "prompt and the post-apply dead man's switch. Use for non-interactive / "
+            "remote runs."
+        ),
     )
     parser.add_argument(
         "-P", "--no-persist",
@@ -89,7 +96,7 @@ Safety:
     parser.add_argument(
         "-n", "--dry-run",
         action="store_true",
-        help="Show proposed changes without applying them",
+        help="Show proposed changes without applying them (implies -c if no mode given)",
     )
     parser.add_argument(
         "-t", "--confirm-timeout",
@@ -159,6 +166,20 @@ def main(argv: List[str] = None) -> int:
     """
     parser = build_parser()
     args = parser.parse_args(argv)
+
+    # `--dry-run` on its own is shorthand for `--configure --dry-run` since
+    # configure is the only mode where a dry-run preview makes sense.
+    if args.dry_run and not (
+        args.validate or args.configure or args.rollback or args.check_prereqs
+    ):
+        args.configure = True
+
+    # Otherwise an action is required.
+    if not (args.validate or args.configure or args.rollback or args.check_prereqs):
+        parser.error(
+            "one of the arguments -V/--validate -c/--configure -r/--rollback "
+            "-p/--check-prereqs is required"
+        )
 
     # Setup
     setup_logging(args.log_file, args.verbose)
@@ -299,8 +320,13 @@ def _do_configure(args: argparse.Namespace, out: Output) -> int:
         # have connectivity before finalising.  If no response within
         # the timeout, auto-rollback to the backup we just saved.
         # Ctrl+C during the countdown also triggers rollback.
+        #
+        # --force skips the dead man's switch entirely so the tool can
+        # run non-interactively (e.g. driven from a remote host where no
+        # one is watching for the prompt).  Caller takes responsibility
+        # for the connectivity check.
         confirm_timeout = getattr(args, "confirm_timeout", 30)
-        if confirm_timeout > 0:
+        if confirm_timeout > 0 and not args.force:
             try:
                 confirmed = out.prompt_timed_confirm(confirm_timeout)
             except KeyboardInterrupt:
@@ -365,7 +391,8 @@ def _do_rollback(args: argparse.Namespace, out: Output) -> int:
         out.header("Rolling Back")
         rollback(backup_path=args.backup_file)
         out.nl()
-        out.info("Rollback complete. Previous SBR configuration has been removed.")
+        out.info("Rollback complete. The configuration that was running "
+                 "when the backup was taken has been restored.")
         out.info("Run 'sbr-config --validate' to verify the current state.")
 
         return 0

--- a/preinstall/sbr-config/sbr_config/cli.py
+++ b/preinstall/sbr-config/sbr_config/cli.py
@@ -278,6 +278,16 @@ def _do_configure(args: argparse.Namespace, out: Output) -> int:
         if failed == 0:
             out.nl()
             out.info("System is correctly configured for source-based routing.")
+            # Self-heal persistence written by <=1.2.0: per-interface sysctl
+            # keys fail at boot for late-created interfaces (e.g. ib*).
+            if not args.no_persist:
+                from .sysctl import refresh_sysctl_persistence_if_stale
+                if refresh_sysctl_persistence_if_stale():
+                    out.info(
+                        "Refreshed /etc/sysctl.d/90-sbr-config.conf: removed "
+                        "per-interface keys that fail at boot for interfaces "
+                        "created by late driver load (e.g. ib*)."
+                    )
             return 0
 
         # Plan changes

--- a/preinstall/sbr-config/sbr_config/constants.py
+++ b/preinstall/sbr-config/sbr_config/constants.py
@@ -12,8 +12,14 @@ TABLE_NAME_PREFIX = "sbr_"
 TABLE_NUMBER_START = 100
 TABLE_NUMBER_MAX = 250  # Stay below 253 (default), 254 (main), 255 (local)
 
-# IP rule priority allocation
-RULE_PRIORITY_START = 100
+# IP rule priority allocation. Base 10000 leaves priorities below free
+# for rules that should take precedence (VPNs, firewall marks, admin
+# rules) and sits in the same neighborhood as cloud tooling conventions
+# (amazon-ec2-net-utils uses 10000+ifindex), while still well before the
+# main table lookup at 32766. Rules created by versions <=1.3.1 used
+# base 100; they keep working and are renumbered on the next
+# rollback + configure cycle.
+RULE_PRIORITY_START = 10000
 RULE_PRIORITY_INCREMENT = 10
 
 # Reserved routing table numbers (never allocate these)

--- a/preinstall/sbr-config/sbr_config/constants.py
+++ b/preinstall/sbr-config/sbr_config/constants.py
@@ -26,6 +26,8 @@ NM_DISPATCHER_SCRIPT = "50-sbr-config"
 
 # systemd-networkd
 SYSTEMD_NETWORK_DIR = "/etc/systemd/network"
+NETWORKD_DROPIN_NAME = "50-sbr.conf"  # inside <applied-file>.network.d/
+NETWORKD_LINKS_STATE_DIR = "/run/systemd/netif/links"
 
 # Netplan
 NETPLAN_DIR = "/etc/netplan"

--- a/preinstall/sbr-config/sbr_config/constants.py
+++ b/preinstall/sbr-config/sbr_config/constants.py
@@ -21,6 +21,9 @@ TABLE_NUMBER_MAX = 250  # Stay below 253 (default), 254 (main), 255 (local)
 # rollback + configure cycle.
 RULE_PRIORITY_START = 10000
 RULE_PRIORITY_INCREMENT = 10
+# Rules at or above the main table lookup (32766) never fire when main
+# holds a default route, so they are dead configuration. Hard ceiling.
+RULE_PRIORITY_MAX = 32765
 
 # Reserved routing table numbers (never allocate these)
 RESERVED_TABLE_NUMBERS = {0, 253, 254, 255}

--- a/preinstall/sbr-config/sbr_config/constants.py
+++ b/preinstall/sbr-config/sbr_config/constants.py
@@ -40,7 +40,11 @@ INTERFACES_D_DIR = "/etc/network/interfaces.d"
 # Marker comment for managed files
 MANAGED_COMMENT = "# Managed by sbr-config -- do not edit manually"
 
-# DHCP lease file search paths
+# DHCP lease file search paths. Every pattern MUST be scoped to {iface} --
+# an unscoped glob makes every interface inherit the first lease's router
+# (a VLAN with no gateway then gets the parent NIC's, and the planned
+# default route fails or misroutes). systemd-networkd leases are keyed by
+# ifindex, not name, and are handled separately in the detector.
 DHCP_LEASE_PATHS = [
     "/var/lib/dhclient/dhclient-{iface}.leases",
     "/var/lib/dhclient/dhclient-{iface}.lease",
@@ -49,8 +53,10 @@ DHCP_LEASE_PATHS = [
     "/var/lib/dhcp/dhclient-{iface}.leases",
     "/var/lib/NetworkManager/dhclient-*-{iface}.lease",
     "/var/lib/NetworkManager/internal-*-{iface}.lease",
-    "/run/systemd/netif/leases/*",
 ]
+
+# systemd-networkd lease files, keyed by interface index
+NETWORKD_LEASE_DIR = "/run/systemd/netif/leases"
 
 # Sysctl settings required for SBR
 SYSCTL_SETTINGS = {

--- a/preinstall/sbr-config/sbr_config/detector.py
+++ b/preinstall/sbr-config/sbr_config/detector.py
@@ -13,6 +13,8 @@ from .constants import (
     DHCP_LEASE_PATHS,
     INTERFACES_FILE,
     NETPLAN_DIR,
+    RESERVED_TABLE_NAMES,
+    RESERVED_TABLE_NUMBERS,
     RT_TABLES_PATH,
     SYSTEMD_NETWORK_DIR,
 )
@@ -469,6 +471,8 @@ def _parse_rt_tables(content: str) -> List[RoutingTable]:
         except ValueError:
             continue
         name = parts[1].strip()
+        if number in RESERVED_TABLE_NUMBERS or name in RESERVED_TABLE_NAMES:
+            continue
         tables.append(RoutingTable(number=number, name=name))
     return tables
 

--- a/preinstall/sbr-config/sbr_config/detector.py
+++ b/preinstall/sbr-config/sbr_config/detector.py
@@ -13,6 +13,7 @@ from .constants import (
     DHCP_LEASE_PATHS,
     INTERFACES_FILE,
     NETPLAN_DIR,
+    NETWORKD_LEASE_DIR,
     RESERVED_TABLE_NAMES,
     RESERVED_TABLE_NUMBERS,
     RT_TABLES_PATH,
@@ -89,6 +90,11 @@ def detect_system_state(
             routes_by_table[rt.name] = table_routes
     rules = _detect_rules(use_json)
 
+    # Table numbers actively used by the kernel (routes or rules),
+    # including numeric-only tables absent from rt_tables (e.g.
+    # cloud-init per-ENI policy routing). Planner must not allocate them.
+    active_table_numbers = _detect_active_table_numbers(rules)
+
     # Detect sysctl values
     iface_names = [i.name for i in interfaces if not i.is_loopback]
     sysctl_values = read_all_sysctl_values(iface_names)
@@ -106,6 +112,7 @@ def detect_system_state(
         sysctl_values=sysctl_values,
         network_manager=network_manager,
         timestamp=datetime.now(timezone.utc).isoformat(),
+        active_table_numbers=active_table_numbers,
     )
 
 
@@ -448,6 +455,30 @@ def _parse_rule_text(line: str) -> Optional[Rule]:
     )
 
 
+def _detect_active_table_numbers(rules: List[Rule]) -> List[int]:
+    """Collect every numeric routing table id the kernel is using.
+
+    Sources: routes in any table (`ip route show table all` prints a
+    'table <id>' suffix for non-main tables) and policy rules whose
+    table reference is numeric (names were already resolved via
+    rt_tables; numeric-only tables never appear there).
+    """
+    numbers = set()
+
+    result = run_command("ip route show table all", check=False)
+    for m in re.finditer(r'\btable\s+(\d+)\b', result.stdout):
+        numbers.add(int(m.group(1)))
+
+    for rule in rules:
+        if rule.table is not None:
+            try:
+                numbers.add(int(rule.table))
+            except (TypeError, ValueError):
+                pass  # named table -- covered by rt_tables parsing
+
+    return sorted(numbers)
+
+
 # ---------------------------------------------------------------------------
 # Routing table file parsing
 # ---------------------------------------------------------------------------
@@ -535,25 +566,45 @@ def _gateway_from_existing_routes(iface: InterfaceInfo, use_json: bool) -> Optio
 
 
 def _gateway_from_dhcp_leases(iface: InterfaceInfo) -> Optional[str]:
-    """Search DHCP lease files for gateway information."""
+    """Search DHCP lease files for gateway information.
+
+    Every lookup is scoped to THIS interface: dhclient-style paths embed
+    the interface name, and systemd-networkd leases are keyed by the
+    interface's ifindex. An unscoped search would hand a VLAN or
+    non-routable interface the router from some other NIC's lease.
+    """
     for pattern in DHCP_LEASE_PATHS:
         path = pattern.format(iface=iface.name)
-        matched_files = glob.glob(path)
-        for lease_file in matched_files:
-            try:
-                content = read_file(lease_file)
-                if not content:
-                    continue
-                # dhclient format: "option routers 10.0.2.1;"
-                m = re.search(r'option\s+routers\s+([\d.]+)', content)
-                if m:
-                    return m.group(1)
-                # systemd-networkd lease format: "ROUTER=10.0.2.1"
-                m = re.search(r'ROUTER=([\d.]+)', content)
-                if m:
-                    return m.group(1)
-            except Exception as e:
-                logger.debug("Error reading lease file %s: %s", lease_file, e)
+        for lease_file in glob.glob(path):
+            gw = _router_from_lease_file(lease_file)
+            if gw:
+                return gw
+
+    # systemd-networkd: lease file named by this interface's ifindex
+    try:
+        with open("/sys/class/net/{}/ifindex".format(iface.name)) as f:
+            ifindex = f.read().strip()
+    except OSError:
+        return None
+    return _router_from_lease_file(os.path.join(NETWORKD_LEASE_DIR, ifindex))
+
+
+def _router_from_lease_file(lease_file: str) -> Optional[str]:
+    """Extract the router/gateway address from one DHCP lease file."""
+    try:
+        content = read_file(lease_file)
+        if not content:
+            return None
+        # dhclient format: "option routers 10.0.2.1;"
+        m = re.search(r'option\s+routers\s+([\d.]+)', content)
+        if m:
+            return m.group(1)
+        # systemd-networkd lease format: "ROUTER=10.0.2.1"
+        m = re.search(r'ROUTER=([\d.]+)', content)
+        if m:
+            return m.group(1)
+    except Exception as e:
+        logger.debug("Error reading lease file %s: %s", lease_file, e)
     return None
 
 

--- a/preinstall/sbr-config/sbr_config/logger.py
+++ b/preinstall/sbr-config/sbr_config/logger.py
@@ -33,7 +33,9 @@ def setup_logging(
     if log_file is not None:
         path = log_file if log_file else LOG_FILE_DEFAULT
         try:
-            os.makedirs(os.path.dirname(path), exist_ok=True)
+            log_dir = os.path.dirname(path)
+            if log_dir:
+                os.makedirs(log_dir, exist_ok=True)
             fh = logging.FileHandler(path)
             fh.setLevel(logging.DEBUG)
             fh.setFormatter(logging.Formatter(
@@ -41,7 +43,7 @@ def setup_logging(
                 datefmt="%Y-%m-%d %H:%M:%S",
             ))
             root_logger.addHandler(fh)
-        except PermissionError:
+        except OSError:
             # Non-fatal: can't write log file but tool should still work
             pass
 

--- a/preinstall/sbr-config/sbr_config/models.py
+++ b/preinstall/sbr-config/sbr_config/models.py
@@ -225,6 +225,7 @@ class SystemState(object):
         sysctl_values,      # type: Dict[str, str]
         network_manager,    # type: NetworkManagerType
         timestamp,          # type: str
+        active_table_numbers=None,  # type: Optional[List[int]]
     ):
         self.interfaces = interfaces
         self.routing_tables = routing_tables
@@ -235,6 +236,11 @@ class SystemState(object):
         self.sysctl_values = sysctl_values
         self.network_manager = network_manager
         self.timestamp = timestamp
+        # Table numbers the kernel is actively using (routes or rules),
+        # including numeric-only tables that never appear in rt_tables --
+        # e.g. cloud-init's per-ENI policy routing. The planner must not
+        # allocate these.
+        self.active_table_numbers = active_table_numbers or []
 
     def to_dict(self):
         # type: () -> dict
@@ -249,6 +255,7 @@ class SystemState(object):
         }
         d["rules"] = [r._asdict() for r in self.rules]
         d["rt_tables_file_content"] = self.rt_tables_file_content
+        d["active_table_numbers"] = self.active_table_numbers
         d["sysctl_values"] = self.sysctl_values
         d["network_manager"] = self.network_manager.value
         d["timestamp"] = self.timestamp

--- a/preinstall/sbr-config/sbr_config/persistence.py
+++ b/preinstall/sbr-config/sbr_config/persistence.py
@@ -3,7 +3,8 @@
 import glob
 import logging
 import os
-from typing import List
+import re
+from typing import Dict, List
 
 from .constants import (
     INTERFACES_D_DIR,
@@ -103,10 +104,42 @@ def write_persistence(
         )
 
     logger.info("Using persistence backend: %s", backend.describe())
-    backend_files = backend.write_config(sbr_interfaces, tables, changes)
+    rule_priorities = _collect_rule_priorities(state, changes)
+    backend_files = backend.write_config(
+        sbr_interfaces, tables, changes, rule_priorities
+    )
     files_written.extend(backend_files)
 
     return files_written
+
+
+def _collect_rule_priorities(state, changes: List[PlannedChange]) -> Dict[str, int]:
+    """Map source IP -> the rule priority actually in effect for it.
+
+    Persistence follows the real priorities (existing kernel rules for
+    sbr_ tables, overridden by this run's planned rules) rather than
+    recomputing from the default base -- so a later run without the
+    --rule-priority flag can't renumber persisted files out from under a
+    configured system. Backends fall back to the derived formula only
+    for IPs absent from this map.
+    """
+    priorities: Dict[str, int] = {}
+
+    for rule in state.rules:
+        if (rule.selector_from and rule.table
+                and str(rule.table).startswith(TABLE_NAME_PREFIX)):
+            ip = rule.selector_from.split("/")[0]
+            priorities[ip] = rule.priority
+
+    for change in changes:
+        if change.change_type != ChangeType.ADD_RULE:
+            continue
+        m = re.search(r"from\s+(\S+)\s+table\s+\S+\s+priority\s+(\d+)",
+                      change.command)
+        if m:
+            priorities[m.group(1).split("/")[0]] = int(m.group(2))
+
+    return priorities
 
 
 def interface_persistence_exists() -> bool:

--- a/preinstall/sbr-config/sbr_config/persistence.py
+++ b/preinstall/sbr-config/sbr_config/persistence.py
@@ -39,8 +39,16 @@ def write_persistence(
     """
     files_written = []
 
-    # Write sysctl persistence (common to all backends)
-    sysctl_path = write_sysctl_persistence(changes)
+    # Write sysctl persistence (common to all backends). Uses the full set
+    # of non-default up interfaces, deduplicated -- interfaces with several
+    # addresses appear once per address in state.interfaces.
+    sysctl_iface_names = []
+    for iface in state.interfaces:
+        if iface.is_loopback or iface.is_default_route_interface or not iface.is_up:
+            continue
+        if iface.name not in sysctl_iface_names:
+            sysctl_iface_names.append(iface.name)
+    sysctl_path = write_sysctl_persistence(sysctl_iface_names)
     if sysctl_path:
         files_written.append(sysctl_path)
 

--- a/preinstall/sbr-config/sbr_config/persistence.py
+++ b/preinstall/sbr-config/sbr_config/persistence.py
@@ -39,16 +39,10 @@ def write_persistence(
     """
     files_written = []
 
-    # Write sysctl persistence (common to all backends). Uses the full set
-    # of non-default up interfaces, deduplicated -- interfaces with several
-    # addresses appear once per address in state.interfaces.
-    sysctl_iface_names = []
-    for iface in state.interfaces:
-        if iface.is_loopback or iface.is_default_route_interface or not iface.is_up:
-            continue
-        if iface.name not in sysctl_iface_names:
-            sysctl_iface_names.append(iface.name)
-    sysctl_path = write_sysctl_persistence(sysctl_iface_names)
+    # Write sysctl persistence (common to all backends). Globals only --
+    # per-interface keys break at boot for interfaces created by late
+    # driver load (see write_sysctl_persistence).
+    sysctl_path = write_sysctl_persistence()
     if sysctl_path:
         files_written.append(sysctl_path)
 

--- a/preinstall/sbr-config/sbr_config/persistence.py
+++ b/preinstall/sbr-config/sbr_config/persistence.py
@@ -1,9 +1,22 @@
 """Persistence dispatch: select and invoke the correct backend."""
 
+import glob
 import logging
+import os
 from typing import List
 
-from .constants import TABLE_NAME_PREFIX
+from .constants import (
+    INTERFACES_D_DIR,
+    INTERFACES_FILE,
+    MANAGED_COMMENT,
+    NETPLAN_CONFIG_FILE,
+    NETPLAN_DIR,
+    NETWORKD_DROPIN_NAME,
+    NM_DISPATCHER_DIR,
+    NM_DISPATCHER_SCRIPT,
+    SYSTEMD_NETWORK_DIR,
+    TABLE_NAME_PREFIX,
+)
 from .exceptions import PersistenceError
 from .models import (
     ChangeType,
@@ -94,6 +107,30 @@ def write_persistence(
     files_written.extend(backend_files)
 
     return files_written
+
+
+def interface_persistence_exists() -> bool:
+    """Check whether any managed interface-level persistence is present.
+
+    Used on clean --configure runs to warn when runtime SBR is correct
+    but nothing would restore it after a reboot.
+    """
+    from .utils import read_file
+
+    if os.path.exists(os.path.join(NM_DISPATCHER_DIR, NM_DISPATCHER_SCRIPT)):
+        return True
+    if os.path.exists(os.path.join(NETPLAN_DIR, NETPLAN_CONFIG_FILE)):
+        return True
+    if glob.glob(os.path.join(SYSTEMD_NETWORK_DIR, "*.network.d", NETWORKD_DROPIN_NAME)):
+        return True
+    if glob.glob(os.path.join(SYSTEMD_NETWORK_DIR, "50-sbr-*.network")):
+        return True  # legacy networkd layout (<=1.2.x)
+    if glob.glob(os.path.join(INTERFACES_D_DIR, "sbr-*")):
+        return True
+    interfaces_content = read_file(INTERFACES_FILE)
+    if interfaces_content and MANAGED_COMMENT in interfaces_content:
+        return True
+    return False
 
 
 def _select_backend(nm_type: NetworkManagerType):

--- a/preinstall/sbr-config/sbr_config/persistence_backends/base.py
+++ b/preinstall/sbr-config/sbr_config/persistence_backends/base.py
@@ -2,9 +2,36 @@
 
 from abc import ABC, abstractmethod
 from collections import OrderedDict
-from typing import List, Tuple
+from typing import Dict, List, Optional, Tuple
 
+from ..constants import (
+    RULE_PRIORITY_INCREMENT,
+    RULE_PRIORITY_START,
+    TABLE_NUMBER_START,
+)
 from ..models import InterfaceInfo, PlannedChange, RoutingTable
+
+
+def rule_priority_for(
+    ip_address: str,
+    table_number: int,
+    rule_priorities: Optional[Dict[str, int]],
+) -> int:
+    """Priority to persist for one source IP's rule.
+
+    Prefers the priority actually in effect (from kernel rules or this
+    run's plan, collected by persistence.py) so persisted files always
+    match runtime -- including custom --rule-priority bases. Falls back
+    to the default derived formula, clamped so pre-existing sbr_ tables
+    numbered below the allocation base can't produce an invalid value.
+    """
+    if rule_priorities and ip_address in rule_priorities:
+        return rule_priorities[ip_address]
+    return max(
+        RULE_PRIORITY_START,
+        RULE_PRIORITY_START
+        + (table_number - TABLE_NUMBER_START) * RULE_PRIORITY_INCREMENT,
+    )
 
 
 def group_by_name(interfaces: List[InterfaceInfo]) -> List[Tuple[str, List[InterfaceInfo]]]:
@@ -30,6 +57,7 @@ class PersistenceBackend(ABC):
         interfaces: List[InterfaceInfo],
         tables: List[RoutingTable],
         changes: List[PlannedChange],
+        rule_priorities: Optional[Dict[str, int]] = None,
     ) -> List[str]:
         """Write persistent configuration files.
 
@@ -37,6 +65,8 @@ class PersistenceBackend(ABC):
             interfaces: Non-default interfaces with SBR configured.
             tables: Routing table assignments.
             changes: The planned changes that were applied.
+            rule_priorities: Source IP -> rule priority actually in
+                             effect (see persistence._collect_rule_priorities).
 
         Returns:
             List of file paths that were created or modified.

--- a/preinstall/sbr-config/sbr_config/persistence_backends/base.py
+++ b/preinstall/sbr-config/sbr_config/persistence_backends/base.py
@@ -1,9 +1,24 @@
 """Abstract base class for persistence backends."""
 
 from abc import ABC, abstractmethod
-from typing import List
+from collections import OrderedDict
+from typing import List, Tuple
 
 from ..models import InterfaceInfo, PlannedChange, RoutingTable
+
+
+def group_by_name(interfaces: List[InterfaceInfo]) -> List[Tuple[str, List[InterfaceInfo]]]:
+    """Group interface entries by name, preserving order.
+
+    state.interfaces holds one entry per IPv4 address, so an interface
+    with several addresses appears several times. Backends must emit ONE
+    config per interface covering all of its addresses -- duplicate
+    stanzas/files/YAML keys are either invalid or silently drop rules.
+    """
+    grouped = OrderedDict()
+    for iface in interfaces:
+        grouped.setdefault(iface.name, []).append(iface)
+    return list(grouped.items())
 
 
 class PersistenceBackend(ABC):

--- a/preinstall/sbr-config/sbr_config/persistence_backends/ifupdown.py
+++ b/preinstall/sbr-config/sbr_config/persistence_backends/ifupdown.py
@@ -9,14 +9,11 @@ from ..constants import (
     INTERFACES_D_DIR,
     INTERFACES_FILE,
     MANAGED_COMMENT,
-    RULE_PRIORITY_INCREMENT,
-    RULE_PRIORITY_START,
     TABLE_NAME_PREFIX,
-    TABLE_NUMBER_START,
 )
 from ..models import InterfaceInfo, PlannedChange, RoutingTable
 from ..utils import read_file, strip_managed_lines, write_file_atomic
-from .base import PersistenceBackend, group_by_name
+from .base import PersistenceBackend, group_by_name, rule_priority_for
 
 logger = logging.getLogger(__name__)
 
@@ -38,6 +35,7 @@ class IfupdownBackend(PersistenceBackend):
         interfaces: List[InterfaceInfo],
         tables: List[RoutingTable],
         changes: List[PlannedChange],
+        rule_priorities=None,
     ) -> List[str]:
         table_num = {t.name: t.number for t in tables}
         written = []
@@ -77,15 +75,13 @@ class IfupdownBackend(PersistenceBackend):
                     f"ip route replace default via {gateway} "
                     f"dev {name} table {table_name}"
                 )
-            # Explicit priority (planner's allocation scheme, clamped):
-            # without it the kernel assigns its own, and the re-added rule
-            # would land at a different precedence than the original.
-            priority = max(
-                RULE_PRIORITY_START,
-                RULE_PRIORITY_START
-                + (tnum - TABLE_NUMBER_START) * RULE_PRIORITY_INCREMENT,
-            )
+            # Explicit priority: without it the kernel assigns its own,
+            # and the re-added rule would land at a different precedence
+            # than the original.
             for entry in entries:
+                priority = rule_priority_for(
+                    entry.ip_address, tnum, rule_priorities
+                )
                 up_cmds.append(
                     f"ip rule add from {entry.ip_address} table {table_name} "
                     f"priority {priority} 2>/dev/null"

--- a/preinstall/sbr-config/sbr_config/persistence_backends/ifupdown.py
+++ b/preinstall/sbr-config/sbr_config/persistence_backends/ifupdown.py
@@ -9,7 +9,10 @@ from ..constants import (
     INTERFACES_D_DIR,
     INTERFACES_FILE,
     MANAGED_COMMENT,
+    RULE_PRIORITY_INCREMENT,
+    RULE_PRIORITY_START,
     TABLE_NAME_PREFIX,
+    TABLE_NUMBER_START,
 )
 from ..models import InterfaceInfo, PlannedChange, RoutingTable
 from ..utils import read_file, strip_managed_lines, write_file_atomic
@@ -74,9 +77,18 @@ class IfupdownBackend(PersistenceBackend):
                     f"ip route replace default via {gateway} "
                     f"dev {name} table {table_name}"
                 )
+            # Explicit priority (planner's allocation scheme, clamped):
+            # without it the kernel assigns its own, and the re-added rule
+            # would land at a different precedence than the original.
+            priority = max(
+                RULE_PRIORITY_START,
+                RULE_PRIORITY_START
+                + (tnum - TABLE_NUMBER_START) * RULE_PRIORITY_INCREMENT,
+            )
             for entry in entries:
                 up_cmds.append(
-                    f"ip rule add from {entry.ip_address} table {table_name} 2>/dev/null"
+                    f"ip rule add from {entry.ip_address} table {table_name} "
+                    f"priority {priority} 2>/dev/null"
                 )
 
             down_cmds = [

--- a/preinstall/sbr-config/sbr_config/persistence_backends/ifupdown.py
+++ b/preinstall/sbr-config/sbr_config/persistence_backends/ifupdown.py
@@ -12,7 +12,7 @@ from ..constants import (
     TABLE_NAME_PREFIX,
 )
 from ..models import InterfaceInfo, PlannedChange, RoutingTable
-from ..utils import read_file, write_file_atomic
+from ..utils import read_file, strip_managed_lines, write_file_atomic
 from .base import PersistenceBackend, group_by_name
 
 logger = logging.getLogger(__name__)
@@ -21,9 +21,13 @@ logger = logging.getLogger(__name__)
 class IfupdownBackend(PersistenceBackend):
     """Write ifupdown configuration for SBR persistence.
 
-    Adds post-up/pre-down lines to interface stanzas in
-    /etc/network/interfaces or creates drop-in files in
-    /etc/network/interfaces.d/.
+    Adds post-up/pre-down lines to the interface's existing stanza --
+    searching /etc/network/interfaces AND the files in
+    /etc/network/interfaces.d/ (stanzas commonly live there via the
+    default `source` line). Only when no stanza exists anywhere does it
+    fall back to creating its own drop-in; a second stanza for an
+    interface that already has one elsewhere would conflict with the
+    original's method.
     """
 
     def write_config(
@@ -40,11 +44,10 @@ class IfupdownBackend(PersistenceBackend):
         # stale) post-up/pre-down blocks. Done before the per-interface
         # loop -- stripping inside it would delete lines just written for
         # an earlier interface in this same run.
-        main_content = read_file(INTERFACES_FILE)
-        if main_content and MANAGED_COMMENT in main_content:
-            write_file_atomic(
-                INTERFACES_FILE, self._remove_managed_lines(main_content)
-            )
+        for path in self._stanza_files():
+            content = read_file(path)
+            if content and MANAGED_COMMENT in content:
+                write_file_atomic(path, strip_managed_lines(content))
 
         for name, entries in group_by_name(interfaces):
             table_name = f"{TABLE_NAME_PREFIX}{name}"
@@ -82,31 +85,53 @@ class IfupdownBackend(PersistenceBackend):
             ]
             down_cmds.append(f"ip route flush table {table_name}")
 
-            # Try to add to existing stanza in interfaces file
-            if self._add_to_interfaces_file(name, up_cmds, down_cmds):
-                written.append(INTERFACES_FILE)
+            # Add to the interface's existing stanza wherever it lives --
+            # the main interfaces file or a sourced interfaces.d file
+            stanza_path = None
+            for path in self._stanza_files():
+                if self._add_to_stanza_file(path, name, up_cmds, down_cmds):
+                    stanza_path = path
+                    break
+            if stanza_path:
+                written.append(stanza_path)
                 continue
 
-            # Fall back to drop-in file
+            # No stanza anywhere: fall back to our own drop-in file
             fpath = self._write_dropin(entries[0], up_cmds, down_cmds)
             if fpath:
                 written.append(fpath)
 
         return written
 
+    def _stanza_files(self) -> List[str]:
+        """Files that may hold interface stanzas: the main interfaces
+        file first, then sourced interfaces.d files (excluding our own
+        sbr-* drop-ins, which are whole-file managed)."""
+        paths = []
+        if os.path.exists(INTERFACES_FILE):
+            paths.append(INTERFACES_FILE)
+        if os.path.isdir(INTERFACES_D_DIR):
+            for fname in sorted(os.listdir(INTERFACES_D_DIR)):
+                if fname.startswith("sbr-"):
+                    continue
+                fpath = os.path.join(INTERFACES_D_DIR, fname)
+                if os.path.isfile(fpath):
+                    paths.append(fpath)
+        return paths
+
     def remove_config(self) -> List[str]:
         removed = []
 
-        # Remove from interfaces file
-        if os.path.exists(INTERFACES_FILE):
-            content = read_file(INTERFACES_FILE)
+        # Strip managed lines from stanza files (main + user drop-ins)
+        for path in self._stanza_files():
+            content = read_file(path)
             if content and MANAGED_COMMENT in content:
-                cleaned = self._remove_managed_lines(content)
+                cleaned = strip_managed_lines(content)
                 if cleaned != content:
-                    write_file_atomic(INTERFACES_FILE, cleaned)
-                    removed.append(INTERFACES_FILE)
+                    write_file_atomic(path, cleaned)
+                    removed.append(path)
 
-        # Remove drop-in files
+        # Remove our own drop-in files
         if os.path.isdir(INTERFACES_D_DIR):
             for fname in os.listdir(INTERFACES_D_DIR):
                 if fname.startswith("sbr-"):
@@ -125,17 +150,18 @@ class IfupdownBackend(PersistenceBackend):
             f"  or drop-in files in {INTERFACES_D_DIR}/"
         )
 
-    def _add_to_interfaces_file(
+    def _add_to_stanza_file(
         self,
+        path: str,
         iface_name: str,
         up_cmds: List[str],
         down_cmds: List[str],
     ) -> bool:
-        """Try to add post-up/pre-down lines to an existing stanza.
+        """Try to add post-up/pre-down lines to an existing stanza in path.
 
         Returns True if successful, False if the stanza wasn't found.
         """
-        content = read_file(INTERFACES_FILE)
+        content = read_file(path)
         if not content:
             return False
 
@@ -145,7 +171,6 @@ class IfupdownBackend(PersistenceBackend):
         if not match:
             return False
 
-        stanza = match.group(0)
         stanza_end = match.end()
 
         # Build lines to insert
@@ -158,8 +183,8 @@ class IfupdownBackend(PersistenceBackend):
 
         # Insert at end of stanza
         new_content = content[:stanza_end] + "\n" + insert_block + content[stanza_end:]
-        write_file_atomic(INTERFACES_FILE, new_content)
-        logger.info("Added SBR lines to %s stanza in %s", iface_name, INTERFACES_FILE)
+        write_file_atomic(path, new_content)
+        logger.info("Added SBR lines to %s stanza in %s", iface_name, path)
         return True
 
     def _write_dropin(
@@ -199,23 +224,3 @@ class IfupdownBackend(PersistenceBackend):
         write_file_atomic(fpath, "\n".join(lines))
         logger.info("Wrote ifupdown drop-in: %s", fpath)
         return fpath
-
-    def _remove_managed_lines(self, content: str) -> str:
-        """Remove lines between MANAGED_COMMENT markers."""
-        lines = content.splitlines()
-        new_lines = []
-        in_managed_block = False
-
-        for line in lines:
-            if MANAGED_COMMENT in line:
-                in_managed_block = True
-                continue
-            if in_managed_block:
-                # Lines in a managed block are indented post-up/pre-down
-                if line.strip().startswith(("post-up", "pre-down")):
-                    continue
-                else:
-                    in_managed_block = False
-            new_lines.append(line)
-
-        return "\n".join(new_lines)

--- a/preinstall/sbr-config/sbr_config/persistence_backends/ifupdown.py
+++ b/preinstall/sbr-config/sbr_config/persistence_backends/ifupdown.py
@@ -13,7 +13,7 @@ from ..constants import (
 )
 from ..models import InterfaceInfo, PlannedChange, RoutingTable
 from ..utils import read_file, write_file_atomic
-from .base import PersistenceBackend
+from .base import PersistenceBackend, group_by_name
 
 logger = logging.getLogger(__name__)
 
@@ -35,39 +35,60 @@ class IfupdownBackend(PersistenceBackend):
         table_num = {t.name: t.number for t in tables}
         written = []
 
-        for iface in interfaces:
-            table_name = f"{TABLE_NAME_PREFIX}{iface.name}"
+        # Strip managed lines from a previous run ONCE up front, so repeat
+        # runs replace them instead of stacking duplicate (and possibly
+        # stale) post-up/pre-down blocks. Done before the per-interface
+        # loop -- stripping inside it would delete lines just written for
+        # an earlier interface in this same run.
+        main_content = read_file(INTERFACES_FILE)
+        if main_content and MANAGED_COMMENT in main_content:
+            write_file_atomic(
+                INTERFACES_FILE, self._remove_managed_lines(main_content)
+            )
+
+        for name, entries in group_by_name(interfaces):
+            table_name = f"{TABLE_NAME_PREFIX}{name}"
             tnum = table_num.get(table_name)
             if tnum is None:
                 continue
 
-            # Derive the full command set from the desired state (not
-            # just this run's delta) so persistence is always complete.
-            up_cmds = [
-                f"ip route replace {iface.subnet} dev {iface.name} "
-                f"src {iface.ip_address} table {table_name}",
-            ]
-            if iface.gateway is not None:
+            # Derive the full command set from the desired state (not just
+            # this run's delta) so persistence is always complete, covering
+            # every address on the interface.
+            up_cmds = []
+            seen_subnets = set()
+            for entry in entries:
+                if entry.subnet in seen_subnets:
+                    continue
+                seen_subnets.add(entry.subnet)
                 up_cmds.append(
-                    f"ip route replace default via {iface.gateway} "
-                    f"dev {iface.name} table {table_name}"
+                    f"ip route replace {entry.subnet} dev {name} "
+                    f"src {entry.ip_address} table {table_name}"
                 )
-            up_cmds.append(
-                f"ip rule add from {iface.ip_address} table {table_name} 2>/dev/null"
-            )
+            gateway = next((e.gateway for e in entries if e.gateway is not None), None)
+            if gateway is not None:
+                up_cmds.append(
+                    f"ip route replace default via {gateway} "
+                    f"dev {name} table {table_name}"
+                )
+            for entry in entries:
+                up_cmds.append(
+                    f"ip rule add from {entry.ip_address} table {table_name} 2>/dev/null"
+                )
 
             down_cmds = [
-                f"ip rule del from {iface.ip_address} table {table_name}",
-                f"ip route flush table {table_name}",
+                f"ip rule del from {entry.ip_address} table {table_name}"
+                for entry in entries
             ]
+            down_cmds.append(f"ip route flush table {table_name}")
 
             # Try to add to existing stanza in interfaces file
-            if self._add_to_interfaces_file(iface.name, up_cmds, down_cmds):
+            if self._add_to_interfaces_file(name, up_cmds, down_cmds):
                 written.append(INTERFACES_FILE)
                 continue
 
             # Fall back to drop-in file
-            fpath = self._write_dropin(iface, up_cmds, down_cmds)
+            fpath = self._write_dropin(entries[0], up_cmds, down_cmds)
             if fpath:
                 written.append(fpath)
 

--- a/preinstall/sbr-config/sbr_config/persistence_backends/netplan.py
+++ b/preinstall/sbr-config/sbr_config/persistence_backends/netplan.py
@@ -1,5 +1,6 @@
 """Netplan YAML persistence backend."""
 
+import glob
 import logging
 import os
 from typing import Dict, List
@@ -16,12 +17,20 @@ from .base import PersistenceBackend, group_by_name
 
 logger = logging.getLogger(__name__)
 
+# Netplan device sections an interface definition can live under. Adding
+# an interface under the wrong section (e.g. a VLAN under ethernets)
+# makes `netplan apply` reject the whole config.
+NETPLAN_SECTIONS = ("ethernets", "vlans", "bonds", "bridges")
+
 
 class NetplanBackend(PersistenceBackend):
     """Write Netplan YAML configuration for SBR persistence.
 
-    Creates /etc/netplan/90-sbr-config.yaml with routing-policy
-    sections for each interface.
+    Creates /etc/netplan/90-sbr-config.yaml. Netplan merges files in
+    lexical order, and a later file's list value REPLACES an earlier
+    file's entirely -- so this file must carry the union of any existing
+    routes / routing-policy for the interfaces it touches, or applying it
+    would delete the user's own static routes on those interfaces.
     """
 
     def write_config(
@@ -33,10 +42,11 @@ class NetplanBackend(PersistenceBackend):
         if not os.path.isdir(NETPLAN_DIR):
             os.makedirs(NETPLAN_DIR, exist_ok=True)
 
-        # Build table name->number mapping
         table_num = {t.name: t.number for t in tables}
+        groups = group_by_name(interfaces)
+        existing = self._load_existing_config([name for name, _ in groups])
 
-        content = self._generate_yaml(interfaces, table_num)
+        content = self._generate_yaml(groups, table_num, existing)
         fpath = os.path.join(NETPLAN_DIR, NETPLAN_CONFIG_FILE)
         write_file_atomic(fpath, content)
 
@@ -63,70 +73,194 @@ class NetplanBackend(PersistenceBackend):
         fpath = os.path.join(NETPLAN_DIR, NETPLAN_CONFIG_FILE)
         return (
             f"Netplan YAML config at {fpath}\n"
-            f"Contains routing-policy rules for each SBR interface."
+            f"Contains routing-policy rules for each SBR interface, merged "
+            f"with any routes those interfaces already had in other files."
         )
+
+    def _load_existing_config(self, iface_names: List[str]) -> Dict[str, dict]:
+        """Learn each managed interface's device section and existing
+        routes / routing-policy from the other netplan files.
+
+        PyYAML is a dependency of netplan itself, so it is importable on
+        any system where this backend runs; if it somehow isn't, fall
+        back to no merge with a loud warning.
+        """
+        result = {
+            name: {
+                "section": "ethernets",
+                "routes": [],
+                "policy": [],
+                "later_conflict": False,
+            }
+            for name in iface_names
+        }
+        try:
+            import yaml
+        except ImportError:
+            logger.warning(
+                "PyYAML unavailable; cannot merge existing netplan routes. "
+                "Routes defined elsewhere for SBR-managed interfaces may be "
+                "overridden by %s.", NETPLAN_CONFIG_FILE,
+            )
+            return result
+
+        for path in sorted(glob.glob(os.path.join(NETPLAN_DIR, "*.yaml"))):
+            basename = os.path.basename(path)
+            if basename == NETPLAN_CONFIG_FILE:
+                continue
+            content = read_file(path)
+            if not content:
+                continue
+            try:
+                data = yaml.safe_load(content) or {}
+            except yaml.YAMLError as e:
+                logger.warning("Could not parse netplan file %s: %s", path, e)
+                continue
+            network = data.get("network") or {}
+            if not isinstance(network, dict):
+                continue
+
+            sorts_after_ours = basename > NETPLAN_CONFIG_FILE
+            for section in NETPLAN_SECTIONS:
+                devices = network.get(section)
+                if not isinstance(devices, dict):
+                    continue
+                for name, cfg in devices.items():
+                    if name not in result or not isinstance(cfg, dict):
+                        continue
+                    result[name]["section"] = section
+                    for yaml_key, dest in (("routes", "routes"),
+                                           ("routing-policy", "policy")):
+                        vals = cfg.get(yaml_key)
+                        if not isinstance(vals, list):
+                            continue
+                        if sorts_after_ours:
+                            # That file's list will override ours wholesale.
+                            result[name]["later_conflict"] = True
+                        else:
+                            result[name][dest].extend(
+                                v for v in vals if isinstance(v, dict)
+                            )
+
+        for name, info in result.items():
+            if info["later_conflict"]:
+                logger.warning(
+                    "A netplan file sorting after %s defines routes or "
+                    "routing-policy for %s; netplan will let it override "
+                    "sbr-config's entries, so SBR persistence for this "
+                    "interface may be incomplete.",
+                    NETPLAN_CONFIG_FILE, name,
+                )
+        return result
 
     def _generate_yaml(
         self,
-        interfaces: List[InterfaceInfo],
+        groups: list,
         table_num: Dict[str, int],
+        existing: Dict[str, dict],
     ) -> str:
         """Generate netplan YAML content.
 
-        We write YAML manually to avoid requiring PyYAML dependency.
+        Written by hand (deterministic output, no dump-format surprises);
+        existing route/policy entries from other files are re-emitted so
+        our whole-list override preserves them.
         """
-        lines = [
+        header = [
             MANAGED_COMMENT,
             "# Source-based routing configuration for multi-NIC systems.",
-            "# This file is merged with other netplan configs.",
+            "# This file is merged with other netplan configs. Routes that",
+            "# other files define for these interfaces are re-emitted here",
+            "# because netplan replaces list values wholesale across files.",
             "",
             "network:",
             "  version: 2",
-            "  ethernets:",
         ]
 
-        for name, entries in group_by_name(interfaces):
+        by_section: Dict[str, List[str]] = {}
+        for name, entries in groups:
             table_name = f"{TABLE_NAME_PREFIX}{name}"
             tnum = table_num.get(table_name)
             if tnum is None:
                 continue
 
-            # Follows the planner's allocation scheme; clamped so pre-existing
-            # sbr_ tables numbered below 100 don't produce a negative priority.
+            info = existing.get(name) or {
+                "section": "ethernets", "routes": [], "policy": [],
+            }
+
+            # Follows the planner's allocation scheme; clamped so
+            # pre-existing sbr_ tables numbered below 100 don't produce a
+            # negative priority.
             priority = max(100, 100 + (tnum - 100) * 10)
 
-            route_lines = [
-                f"    {name}:",
-                f"      routes:",
-            ]
+            block = [f"    {name}:", "      routes:"]
+
+            # Existing routes from other files first, verbatim
+            emitted = set()
+            for route in info["routes"]:
+                block.extend(_emit_mapping_entry(route, indent="        "))
+                emitted.add((str(route.get("to")), str(route.get("table"))))
+
+            # Our SBR routes (skip any an existing entry already covers)
             seen_subnets = set()
             for entry in entries:
                 if entry.subnet in seen_subnets:
                     continue
                 seen_subnets.add(entry.subnet)
-                route_lines.extend([
+                if (entry.subnet, str(tnum)) in emitted:
+                    continue
+                block.extend([
                     f"        - to: {entry.subnet}",
                     f"          table: {tnum}",
                 ])
 
-            # Only add a default route if a gateway is known (one per table)
-            gateway = next((e.gateway for e in entries if e.gateway is not None), None)
-            if gateway is not None:
-                route_lines.extend([
+            gateway = next(
+                (e.gateway for e in entries if e.gateway is not None), None
+            )
+            if gateway is not None and ("default", str(tnum)) not in emitted:
+                block.extend([
                     f"        - to: default",
                     f"          via: {gateway}",
                     f"          table: {tnum}",
                 ])
 
-            route_lines.append(f"      routing-policy:")
+            block.append("      routing-policy:")
+            emitted_policy = set()
+            for policy in info["policy"]:
+                block.extend(_emit_mapping_entry(policy, indent="        "))
+                emitted_policy.add(
+                    (str(policy.get("from")), str(policy.get("table")))
+                )
             for entry in entries:
-                route_lines.extend([
+                if (entry.ip_address, str(tnum)) in emitted_policy:
+                    continue
+                block.extend([
                     f"        - from: {entry.ip_address}",
                     f"          table: {tnum}",
                     f"          priority: {priority}",
                 ])
 
-            lines.extend(route_lines)
+            by_section.setdefault(info["section"], []).extend(block)
+
+        lines = list(header)
+        for section in NETPLAN_SECTIONS:
+            if section in by_section:
+                lines.append(f"  {section}:")
+                lines.extend(by_section[section])
 
         lines.append("")
         return "\n".join(lines)
+
+
+def _emit_mapping_entry(mapping: dict, indent: str) -> List[str]:
+    """Re-serialize a flat YAML mapping as a list item, preserving keys."""
+    lines = []
+    first = True
+    for key, value in mapping.items():
+        if isinstance(value, bool):
+            rendered = "true" if value else "false"
+        else:
+            rendered = str(value)
+        prefix = f"{indent}- " if first else f"{indent}  "
+        lines.append(f"{prefix}{key}: {rendered}")
+        first = False
+    return lines

--- a/preinstall/sbr-config/sbr_config/persistence_backends/netplan.py
+++ b/preinstall/sbr-config/sbr_config/persistence_backends/netplan.py
@@ -9,7 +9,10 @@ from ..constants import (
     MANAGED_COMMENT,
     NETPLAN_CONFIG_FILE,
     NETPLAN_DIR,
+    RULE_PRIORITY_INCREMENT,
+    RULE_PRIORITY_START,
     TABLE_NAME_PREFIX,
+    TABLE_NUMBER_START,
 )
 from ..models import InterfaceInfo, PlannedChange, RoutingTable
 from ..utils import read_file, run_command, write_file_atomic
@@ -207,9 +210,13 @@ class NetplanBackend(PersistenceBackend):
                 continue
 
             # Follows the planner's allocation scheme; clamped so
-            # pre-existing sbr_ tables numbered below 100 don't produce a
-            # negative priority.
-            priority = max(100, 100 + (tnum - 100) * 10)
+            # pre-existing sbr_ tables numbered below the allocation base
+            # don't produce an invalid priority.
+            priority = max(
+                RULE_PRIORITY_START,
+                RULE_PRIORITY_START
+                + (tnum - TABLE_NUMBER_START) * RULE_PRIORITY_INCREMENT,
+            )
 
             block = [f"    {name}:", "      routes:"]
 

--- a/preinstall/sbr-config/sbr_config/persistence_backends/netplan.py
+++ b/preinstall/sbr-config/sbr_config/persistence_backends/netplan.py
@@ -9,14 +9,11 @@ from ..constants import (
     MANAGED_COMMENT,
     NETPLAN_CONFIG_FILE,
     NETPLAN_DIR,
-    RULE_PRIORITY_INCREMENT,
-    RULE_PRIORITY_START,
     TABLE_NAME_PREFIX,
-    TABLE_NUMBER_START,
 )
 from ..models import InterfaceInfo, PlannedChange, RoutingTable
 from ..utils import read_file, run_command, write_file_atomic
-from .base import PersistenceBackend, group_by_name
+from .base import PersistenceBackend, group_by_name, rule_priority_for
 
 logger = logging.getLogger(__name__)
 
@@ -41,6 +38,7 @@ class NetplanBackend(PersistenceBackend):
         interfaces: List[InterfaceInfo],
         tables: List[RoutingTable],
         changes: List[PlannedChange],
+        rule_priorities=None,
     ) -> List[str]:
         if not os.path.isdir(NETPLAN_DIR):
             os.makedirs(NETPLAN_DIR, exist_ok=True)
@@ -49,7 +47,7 @@ class NetplanBackend(PersistenceBackend):
         groups = group_by_name(interfaces)
         existing = self._load_existing_config([name for name, _ in groups])
 
-        content = self._generate_yaml(groups, table_num, existing)
+        content = self._generate_yaml(groups, table_num, existing, rule_priorities)
         fpath = os.path.join(NETPLAN_DIR, NETPLAN_CONFIG_FILE)
         # 0600: netplan warns (newer versions error) on world-readable config
         write_file_atomic(fpath, content, mode=0o600)
@@ -164,6 +162,7 @@ class NetplanBackend(PersistenceBackend):
         groups: list,
         table_num: Dict[str, int],
         existing: Dict[str, dict],
+        rule_priorities=None,
     ) -> str:
         """Generate netplan YAML content.
 
@@ -209,15 +208,6 @@ class NetplanBackend(PersistenceBackend):
                 )
                 continue
 
-            # Follows the planner's allocation scheme; clamped so
-            # pre-existing sbr_ tables numbered below the allocation base
-            # don't produce an invalid priority.
-            priority = max(
-                RULE_PRIORITY_START,
-                RULE_PRIORITY_START
-                + (tnum - TABLE_NUMBER_START) * RULE_PRIORITY_INCREMENT,
-            )
-
             block = [f"    {name}:", "      routes:"]
 
             # Existing routes from other files first, verbatim
@@ -259,6 +249,9 @@ class NetplanBackend(PersistenceBackend):
             for entry in entries:
                 if (entry.ip_address, str(tnum)) in emitted_policy:
                     continue
+                priority = rule_priority_for(
+                    entry.ip_address, tnum, rule_priorities
+                )
                 block.extend([
                     f"        - from: {entry.ip_address}",
                     f"          table: {tnum}",

--- a/preinstall/sbr-config/sbr_config/persistence_backends/netplan.py
+++ b/preinstall/sbr-config/sbr_config/persistence_backends/netplan.py
@@ -12,7 +12,7 @@ from ..constants import (
 )
 from ..models import InterfaceInfo, PlannedChange, RoutingTable
 from ..utils import read_file, run_command, write_file_atomic
-from .base import PersistenceBackend
+from .base import PersistenceBackend, group_by_name
 
 logger = logging.getLogger(__name__)
 
@@ -42,8 +42,8 @@ class NetplanBackend(PersistenceBackend):
 
         logger.info("Wrote netplan config: %s", fpath)
 
-        # Apply netplan
-        run_command("netplan apply", check=False)
+        # Apply netplan (can take a while -- it cycles interface config)
+        run_command("netplan apply", check=False, timeout=60)
 
         return [fpath]
 
@@ -56,7 +56,7 @@ class NetplanBackend(PersistenceBackend):
                 os.unlink(fpath)
                 removed.append(fpath)
                 logger.info("Removed netplan config: %s", fpath)
-                run_command("netplan apply", check=False)
+                run_command("netplan apply", check=False, timeout=60)
         return removed
 
     def describe(self) -> str:
@@ -85,35 +85,46 @@ class NetplanBackend(PersistenceBackend):
             "  ethernets:",
         ]
 
-        for iface in interfaces:
-            table_name = f"{TABLE_NAME_PREFIX}{iface.name}"
+        for name, entries in group_by_name(interfaces):
+            table_name = f"{TABLE_NAME_PREFIX}{name}"
             tnum = table_num.get(table_name)
             if tnum is None:
                 continue
 
-            priority = 100 + (tnum - 100) * 10
+            # Follows the planner's allocation scheme; clamped so pre-existing
+            # sbr_ tables numbered below 100 don't produce a negative priority.
+            priority = max(100, 100 + (tnum - 100) * 10)
 
             route_lines = [
-                f"    {iface.name}:",
+                f"    {name}:",
                 f"      routes:",
-                f"        - to: {iface.subnet}",
-                f"          table: {tnum}",
             ]
-
-            # Only add default route if a gateway is known
-            if iface.gateway is not None:
+            seen_subnets = set()
+            for entry in entries:
+                if entry.subnet in seen_subnets:
+                    continue
+                seen_subnets.add(entry.subnet)
                 route_lines.extend([
-                    f"        - to: default",
-                    f"          via: {iface.gateway}",
+                    f"        - to: {entry.subnet}",
                     f"          table: {tnum}",
                 ])
 
-            route_lines.extend([
-                f"      routing-policy:",
-                f"        - from: {iface.ip_address}",
-                f"          table: {tnum}",
-                f"          priority: {priority}",
-            ])
+            # Only add a default route if a gateway is known (one per table)
+            gateway = next((e.gateway for e in entries if e.gateway is not None), None)
+            if gateway is not None:
+                route_lines.extend([
+                    f"        - to: default",
+                    f"          via: {gateway}",
+                    f"          table: {tnum}",
+                ])
+
+            route_lines.append(f"      routing-policy:")
+            for entry in entries:
+                route_lines.extend([
+                    f"        - from: {entry.ip_address}",
+                    f"          table: {tnum}",
+                    f"          priority: {priority}",
+                ])
 
             lines.extend(route_lines)
 

--- a/preinstall/sbr-config/sbr_config/persistence_backends/netplan.py
+++ b/preinstall/sbr-config/sbr_config/persistence_backends/netplan.py
@@ -48,7 +48,8 @@ class NetplanBackend(PersistenceBackend):
 
         content = self._generate_yaml(groups, table_num, existing)
         fpath = os.path.join(NETPLAN_DIR, NETPLAN_CONFIG_FILE)
-        write_file_atomic(fpath, content)
+        # 0600: netplan warns (newer versions error) on world-readable config
+        write_file_atomic(fpath, content, mode=0o600)
 
         logger.info("Wrote netplan config: %s", fpath)
 
@@ -91,6 +92,7 @@ class NetplanBackend(PersistenceBackend):
                 "routes": [],
                 "policy": [],
                 "later_conflict": False,
+                "defined": False,
             }
             for name in iface_names
         }
@@ -129,6 +131,7 @@ class NetplanBackend(PersistenceBackend):
                     if name not in result or not isinstance(cfg, dict):
                         continue
                     result[name]["section"] = section
+                    result[name]["defined"] = True
                     for yaml_key, dest in (("routes", "routes"),
                                            ("routing-policy", "policy")):
                         vals = cfg.get(yaml_key)
@@ -185,7 +188,23 @@ class NetplanBackend(PersistenceBackend):
 
             info = existing.get(name) or {
                 "section": "ethernets", "routes": [], "policy": [],
+                "defined": False,
             }
+
+            # Only emit entries for interfaces netplan already defines.
+            # Emitting one for an unmanaged interface (e.g. a manually
+            # created VLAN) makes netplan generate a .network for it, and
+            # networkd then takes over the link with no address config --
+            # stripping its addresses on apply.
+            if not info.get("defined"):
+                logger.warning(
+                    "%s is not defined in any netplan file; skipping SBR "
+                    "persistence for it (adding it would make networkd take "
+                    "over the link and drop its address config). Runtime "
+                    "config is active but will not survive a reboot.",
+                    name,
+                )
+                continue
 
             # Follows the planner's allocation scheme; clamped so
             # pre-existing sbr_ tables numbered below 100 don't produce a

--- a/preinstall/sbr-config/sbr_config/persistence_backends/networkmanager.py
+++ b/preinstall/sbr-config/sbr_config/persistence_backends/networkmanager.py
@@ -11,7 +11,7 @@ from ..constants import (
     TABLE_NAME_PREFIX,
 )
 from ..models import InterfaceInfo, PlannedChange, RoutingTable
-from ..utils import read_file, write_file_atomic
+from ..utils import command_exists, read_file, run_command, write_file_atomic
 from .base import PersistenceBackend, group_by_name
 
 logger = logging.getLogger(__name__)
@@ -40,7 +40,28 @@ class NetworkManagerBackend(PersistenceBackend):
         write_file_atomic(script_path, script, mode=0o755)
 
         logger.info("Wrote NM dispatcher script: %s", script_path)
+
+        # The dispatcher only fires for NM-managed devices. Hand-configured
+        # storage NICs are often NM_CONTROLLED=no -- warn, or this
+        # persistence silently does nothing for exactly those interfaces.
+        self._warn_unmanaged(interfaces)
+
         return [script_path]
+
+    def _warn_unmanaged(self, interfaces: List[InterfaceInfo]) -> None:
+        if not command_exists("nmcli"):
+            return
+        for name, _ in group_by_name(interfaces):
+            result = run_command(
+                f"nmcli -t -f GENERAL.STATE device show {name}", check=False
+            )
+            if result.returncode == 0 and "unmanaged" in result.stdout:
+                logger.warning(
+                    "%s is unmanaged by NetworkManager; the dispatcher "
+                    "script never fires for it, so SBR will not be restored "
+                    "on link changes or reboot for this interface.",
+                    name,
+                )
 
     def remove_config(self) -> List[str]:
         script_path = os.path.join(NM_DISPATCHER_DIR, NM_DISPATCHER_SCRIPT)

--- a/preinstall/sbr-config/sbr_config/persistence_backends/networkmanager.py
+++ b/preinstall/sbr-config/sbr_config/persistence_backends/networkmanager.py
@@ -8,14 +8,11 @@ from ..constants import (
     MANAGED_COMMENT,
     NM_DISPATCHER_DIR,
     NM_DISPATCHER_SCRIPT,
-    RULE_PRIORITY_INCREMENT,
-    RULE_PRIORITY_START,
     TABLE_NAME_PREFIX,
-    TABLE_NUMBER_START,
 )
 from ..models import InterfaceInfo, PlannedChange, RoutingTable
 from ..utils import command_exists, read_file, run_command, write_file_atomic
-from .base import PersistenceBackend, group_by_name
+from .base import PersistenceBackend, group_by_name, rule_priority_for
 
 logger = logging.getLogger(__name__)
 
@@ -32,6 +29,7 @@ class NetworkManagerBackend(PersistenceBackend):
         interfaces: List[InterfaceInfo],
         tables: List[RoutingTable],
         changes: List[PlannedChange],
+        rule_priorities=None,
     ) -> List[str]:
         script_path = os.path.join(NM_DISPATCHER_DIR, NM_DISPATCHER_SCRIPT)
 
@@ -39,7 +37,7 @@ class NetworkManagerBackend(PersistenceBackend):
             os.makedirs(NM_DISPATCHER_DIR, exist_ok=True)
 
         # Build the dispatcher script
-        script = self._generate_script(interfaces, tables, changes)
+        script = self._generate_script(interfaces, tables, changes, rule_priorities)
         write_file_atomic(script_path, script, mode=0o755)
 
         logger.info("Wrote NM dispatcher script: %s", script_path)
@@ -89,6 +87,7 @@ class NetworkManagerBackend(PersistenceBackend):
         interfaces: List[InterfaceInfo],
         tables: List[RoutingTable],
         changes: List[PlannedChange],
+        rule_priorities=None,
     ) -> str:
         """Generate the bash dispatcher script content.
 
@@ -134,15 +133,13 @@ class NetworkManagerBackend(PersistenceBackend):
                     f"ip route replace default via {gateway} "
                     f"dev {name} table {table_name}"
                 )
-            # Explicit priority (planner's allocation scheme, clamped):
-            # without it the kernel assigns its own, and the re-added rule
-            # would land at a different precedence than the original.
-            priority = max(
-                RULE_PRIORITY_START,
-                RULE_PRIORITY_START
-                + (tnum - TABLE_NUMBER_START) * RULE_PRIORITY_INCREMENT,
-            )
+            # Explicit priority: without it the kernel assigns its own,
+            # and the re-added rule would land at a different precedence
+            # than the original.
             for entry in entries:
+                priority = rule_priority_for(
+                    entry.ip_address, tnum, rule_priorities
+                )
                 up_commands.append(
                     f"ip rule add from {entry.ip_address} table {table_name} "
                     f"priority {priority} 2>/dev/null"

--- a/preinstall/sbr-config/sbr_config/persistence_backends/networkmanager.py
+++ b/preinstall/sbr-config/sbr_config/persistence_backends/networkmanager.py
@@ -12,7 +12,7 @@ from ..constants import (
 )
 from ..models import InterfaceInfo, PlannedChange, RoutingTable
 from ..utils import read_file, write_file_atomic
-from .base import PersistenceBackend
+from .base import PersistenceBackend, group_by_name
 
 logger = logging.getLogger(__name__)
 
@@ -86,32 +86,42 @@ class NetworkManagerBackend(PersistenceBackend):
             'case "$IFACE" in',
         ]
 
-        for iface in interfaces:
-            table_name = f"{TABLE_NAME_PREFIX}{iface.name}"
+        for name, entries in group_by_name(interfaces):
+            table_name = f"{TABLE_NAME_PREFIX}{name}"
             tnum = table_num.get(table_name)
             if tnum is None:
                 continue
 
-            # Derive the full command set from the desired state
-            up_commands = [
-                f"ip route replace {iface.subnet} dev {iface.name} "
-                f"src {iface.ip_address} table {table_name}",
-            ]
-            if iface.gateway is not None:
+            # Derive the full command set from the desired state, covering
+            # every address on the interface
+            up_commands = []
+            seen_subnets = set()
+            for entry in entries:
+                if entry.subnet in seen_subnets:
+                    continue
+                seen_subnets.add(entry.subnet)
                 up_commands.append(
-                    f"ip route replace default via {iface.gateway} "
-                    f"dev {iface.name} table {table_name}"
+                    f"ip route replace {entry.subnet} dev {name} "
+                    f"src {entry.ip_address} table {table_name}"
                 )
-            up_commands.append(
-                f"ip rule add from {iface.ip_address} table {table_name} 2>/dev/null"
-            )
+            gateway = next((e.gateway for e in entries if e.gateway is not None), None)
+            if gateway is not None:
+                up_commands.append(
+                    f"ip route replace default via {gateway} "
+                    f"dev {name} table {table_name}"
+                )
+            for entry in entries:
+                up_commands.append(
+                    f"ip rule add from {entry.ip_address} table {table_name} 2>/dev/null"
+                )
 
             down_commands = [
-                f"ip rule del from {iface.ip_address} table {table_name}",
-                f"ip route flush table {table_name}",
+                f"ip rule del from {entry.ip_address} table {table_name}"
+                for entry in entries
             ]
+            down_commands.append(f"ip route flush table {table_name}")
 
-            lines.append(f"    {iface.name})")
+            lines.append(f"    {name})")
             lines.append('        if [ "$ACTION" = "up" ]; then')
             for cmd in up_commands:
                 lines.append(f"            {cmd}")

--- a/preinstall/sbr-config/sbr_config/persistence_backends/networkmanager.py
+++ b/preinstall/sbr-config/sbr_config/persistence_backends/networkmanager.py
@@ -8,7 +8,10 @@ from ..constants import (
     MANAGED_COMMENT,
     NM_DISPATCHER_DIR,
     NM_DISPATCHER_SCRIPT,
+    RULE_PRIORITY_INCREMENT,
+    RULE_PRIORITY_START,
     TABLE_NAME_PREFIX,
+    TABLE_NUMBER_START,
 )
 from ..models import InterfaceInfo, PlannedChange, RoutingTable
 from ..utils import command_exists, read_file, run_command, write_file_atomic
@@ -131,9 +134,18 @@ class NetworkManagerBackend(PersistenceBackend):
                     f"ip route replace default via {gateway} "
                     f"dev {name} table {table_name}"
                 )
+            # Explicit priority (planner's allocation scheme, clamped):
+            # without it the kernel assigns its own, and the re-added rule
+            # would land at a different precedence than the original.
+            priority = max(
+                RULE_PRIORITY_START,
+                RULE_PRIORITY_START
+                + (tnum - TABLE_NUMBER_START) * RULE_PRIORITY_INCREMENT,
+            )
             for entry in entries:
                 up_commands.append(
-                    f"ip rule add from {entry.ip_address} table {table_name} 2>/dev/null"
+                    f"ip rule add from {entry.ip_address} table {table_name} "
+                    f"priority {priority} 2>/dev/null"
                 )
 
             down_commands = [

--- a/preinstall/sbr-config/sbr_config/persistence_backends/systemd_networkd.py
+++ b/preinstall/sbr-config/sbr_config/persistence_backends/systemd_networkd.py
@@ -9,15 +9,12 @@ from ..constants import (
     MANAGED_COMMENT,
     NETWORKD_DROPIN_NAME,
     NETWORKD_LINKS_STATE_DIR,
-    RULE_PRIORITY_INCREMENT,
-    RULE_PRIORITY_START,
     SYSTEMD_NETWORK_DIR,
     TABLE_NAME_PREFIX,
-    TABLE_NUMBER_START,
 )
 from ..models import InterfaceInfo, PlannedChange, RoutingTable
 from ..utils import read_file, run_command, write_file_atomic
-from .base import PersistenceBackend, group_by_name
+from .base import PersistenceBackend, group_by_name, rule_priority_for
 
 logger = logging.getLogger(__name__)
 
@@ -40,6 +37,7 @@ class SystemdNetworkdBackend(PersistenceBackend):
         interfaces: List[InterfaceInfo],
         tables: List[RoutingTable],
         changes: List[PlannedChange],
+        rule_priorities=None,
     ) -> List[str]:
         table_num = {t.name: t.number for t in tables}
 
@@ -72,7 +70,10 @@ class SystemdNetworkdBackend(PersistenceBackend):
             )
             os.makedirs(dropin_dir, exist_ok=True)
             fpath = os.path.join(dropin_dir, NETWORKD_DROPIN_NAME)
-            write_file_atomic(fpath, self._generate_dropin(name, entries, tnum))
+            write_file_atomic(
+                fpath,
+                self._generate_dropin(name, entries, tnum, rule_priorities),
+            )
             written.append(fpath)
             logger.info("Wrote networkd drop-in: %s", fpath)
 
@@ -156,21 +157,13 @@ class SystemdNetworkdBackend(PersistenceBackend):
         name: str,
         entries: List[InterfaceInfo],
         table_number: int,
+        rule_priorities=None,
     ) -> str:
         """Generate drop-in content: routes and policy rules only.
 
         No [Match] section -- the drop-in merges into the .network file
         that already matches the link.
         """
-        # Follows the planner's allocation scheme; clamped so pre-existing
-        # sbr_ tables numbered below the allocation base don't produce an
-        # invalid priority.
-        priority = max(
-            RULE_PRIORITY_START,
-            RULE_PRIORITY_START
-            + (table_number - TABLE_NUMBER_START) * RULE_PRIORITY_INCREMENT,
-        )
-
         ips = ", ".join(e.ip_address for e in entries)
         lines = [
             MANAGED_COMMENT,
@@ -201,6 +194,9 @@ class SystemdNetworkdBackend(PersistenceBackend):
             ])
 
         for entry in entries:
+            priority = rule_priority_for(
+                entry.ip_address, table_number, rule_priorities
+            )
             lines.extend([
                 "[RoutingPolicyRule]",
                 f"From={entry.ip_address}",

--- a/preinstall/sbr-config/sbr_config/persistence_backends/systemd_networkd.py
+++ b/preinstall/sbr-config/sbr_config/persistence_backends/systemd_networkd.py
@@ -1,10 +1,17 @@
-"""systemd-networkd .network file persistence backend."""
+"""systemd-networkd drop-in persistence backend."""
 
+import glob
 import logging
 import os
-from typing import List
+from typing import List, Optional
 
-from ..constants import MANAGED_COMMENT, SYSTEMD_NETWORK_DIR, TABLE_NAME_PREFIX
+from ..constants import (
+    MANAGED_COMMENT,
+    NETWORKD_DROPIN_NAME,
+    NETWORKD_LINKS_STATE_DIR,
+    SYSTEMD_NETWORK_DIR,
+    TABLE_NAME_PREFIX,
+)
 from ..models import InterfaceInfo, PlannedChange, RoutingTable
 from ..utils import read_file, run_command, write_file_atomic
 from .base import PersistenceBackend, group_by_name
@@ -13,10 +20,16 @@ logger = logging.getLogger(__name__)
 
 
 class SystemdNetworkdBackend(PersistenceBackend):
-    """Write systemd-networkd .network files for SBR persistence.
+    """Write systemd-networkd drop-in configs for SBR persistence.
 
-    Creates /etc/systemd/network/50-sbr-<iface>.network files with
-    [Route] and [RoutingPolicyRule] sections.
+    networkd applies exactly ONE .network file per link -- the first
+    match in lexical order; all later matches are ignored
+    (systemd.network(5)). A standalone SBR .network file therefore either
+    shadows the file that actually configures the link (stripping its
+    address management, since KeepConfiguration defaults to off) or is
+    silently ignored. SBR settings must instead go into a drop-in,
+    <applied-file>.network.d/50-sbr.conf, which merges into whichever
+    file networkd already applies to the link.
     """
 
     def write_config(
@@ -25,44 +38,63 @@ class SystemdNetworkdBackend(PersistenceBackend):
         tables: List[RoutingTable],
         changes: List[PlannedChange],
     ) -> List[str]:
-        if not os.path.isdir(SYSTEMD_NETWORK_DIR):
-            os.makedirs(SYSTEMD_NETWORK_DIR, exist_ok=True)
-
-        # Build table name->number mapping
         table_num = {t.name: t.number for t in tables}
 
+        # Versions <=1.2.x wrote dangerous standalone 50-sbr-*.network
+        # files (see class docstring); shed them before writing drop-ins.
+        removed_legacy = self._remove_legacy_files()
+
         written = []
+        skipped = []
         for name, entries in group_by_name(interfaces):
             table_name = f"{TABLE_NAME_PREFIX}{name}"
             tnum = table_num.get(table_name)
             if tnum is None:
                 continue
 
-            content = self._generate_network_file(name, entries, tnum)
-            fpath = os.path.join(SYSTEMD_NETWORK_DIR, f"50-sbr-{name}.network")
-            write_file_atomic(fpath, content)
-            written.append(fpath)
-            logger.info("Wrote networkd config: %s", fpath)
+            network_file = self._applied_network_file(name)
+            if network_file is None:
+                skipped.append(name)
+                logger.warning(
+                    "%s has no systemd-networkd .network file applied to it "
+                    "(unmanaged by networkd); skipping SBR persistence for "
+                    "this interface. Runtime config is active but will not "
+                    "survive a reboot.",
+                    name,
+                )
+                continue
 
-        # Reload networkd
-        if written:
+            dropin_dir = os.path.join(
+                SYSTEMD_NETWORK_DIR, os.path.basename(network_file) + ".d"
+            )
+            os.makedirs(dropin_dir, exist_ok=True)
+            fpath = os.path.join(dropin_dir, NETWORKD_DROPIN_NAME)
+            write_file_atomic(fpath, self._generate_dropin(name, entries, tnum))
+            written.append(fpath)
+            logger.info("Wrote networkd drop-in: %s", fpath)
+
+        if written or removed_legacy:
             run_command("networkctl reload", check=False, timeout=30)
 
         return written
 
     def remove_config(self) -> List[str]:
         removed = []
-        if not os.path.isdir(SYSTEMD_NETWORK_DIR):
-            return removed
 
-        for fname in os.listdir(SYSTEMD_NETWORK_DIR):
-            if fname.startswith("50-sbr-") and fname.endswith(".network"):
-                fpath = os.path.join(SYSTEMD_NETWORK_DIR, fname)
-                content = read_file(fpath)
-                if content and MANAGED_COMMENT in content:
-                    os.unlink(fpath)
-                    removed.append(fpath)
-                    logger.info("Removed networkd config: %s", fpath)
+        for fpath in glob.glob(
+            os.path.join(SYSTEMD_NETWORK_DIR, "*.network.d", NETWORKD_DROPIN_NAME)
+        ):
+            content = read_file(fpath)
+            if content and MANAGED_COMMENT in content:
+                os.unlink(fpath)
+                removed.append(fpath)
+                logger.info("Removed networkd drop-in: %s", fpath)
+                try:
+                    os.rmdir(os.path.dirname(fpath))
+                except OSError:
+                    pass  # not empty
+
+        removed += self._remove_legacy_files()
 
         if removed:
             run_command("networkctl reload", check=False, timeout=30)
@@ -71,19 +103,61 @@ class SystemdNetworkdBackend(PersistenceBackend):
 
     def describe(self) -> str:
         return (
-            f"systemd-networkd .network files in {SYSTEMD_NETWORK_DIR}/\n"
-            f"Files named 50-sbr-<interface>.network with Route and RoutingPolicyRule sections."
+            f"systemd-networkd drop-ins: "
+            f"{SYSTEMD_NETWORK_DIR}/<applied-file>.network.d/{NETWORKD_DROPIN_NAME}\n"
+            f"Merged into the .network file networkd already applies to each link."
         )
 
-    def _generate_network_file(
+    def _remove_legacy_files(self) -> List[str]:
+        """Remove standalone 50-sbr-*.network files written by <=1.2.x."""
+        removed = []
+        if not os.path.isdir(SYSTEMD_NETWORK_DIR):
+            return removed
+        for fname in os.listdir(SYSTEMD_NETWORK_DIR):
+            if not (fname.startswith("50-sbr-") and fname.endswith(".network")):
+                continue
+            fpath = os.path.join(SYSTEMD_NETWORK_DIR, fname)
+            content = read_file(fpath)
+            if content and MANAGED_COMMENT in content:
+                os.unlink(fpath)
+                removed.append(fpath)
+                logger.info(
+                    "Removed legacy standalone networkd file %s (could shadow "
+                    "or be shadowed by the link's real .network file)",
+                    fpath,
+                )
+        return removed
+
+    def _applied_network_file(self, name: str) -> Optional[str]:
+        """Find the .network file networkd currently applies to a link.
+
+        Read from networkd's runtime state (NETWORK_FILE= in
+        /run/systemd/netif/links/<ifindex>); returns None when networkd
+        doesn't manage the link.
+        """
+        try:
+            with open("/sys/class/net/{}/ifindex".format(name)) as f:
+                ifindex = f.read().strip()
+        except OSError:
+            return None
+        state = read_file(os.path.join(NETWORKD_LINKS_STATE_DIR, ifindex))
+        if not state:
+            return None
+        for line in state.splitlines():
+            if line.startswith("NETWORK_FILE="):
+                return line.split("=", 1)[1].strip() or None
+        return None
+
+    def _generate_dropin(
         self,
         name: str,
         entries: List[InterfaceInfo],
         table_number: int,
     ) -> str:
-        """Generate a .network file for a single interface.
+        """Generate drop-in content: routes and policy rules only.
 
-        ``entries`` holds one InterfaceInfo per address on the interface.
+        No [Match] section -- the drop-in merges into the .network file
+        that already matches the link.
         """
         # Follows the planner's allocation scheme; clamped so pre-existing
         # sbr_ tables numbered below 100 don't produce an invalid negative
@@ -94,9 +168,6 @@ class SystemdNetworkdBackend(PersistenceBackend):
         lines = [
             MANAGED_COMMENT,
             f"# Source-based routing for {name} ({ips})",
-            "",
-            "[Match]",
-            f"Name={name}",
             "",
         ]
 

--- a/preinstall/sbr-config/sbr_config/persistence_backends/systemd_networkd.py
+++ b/preinstall/sbr-config/sbr_config/persistence_backends/systemd_networkd.py
@@ -7,7 +7,7 @@ from typing import List
 from ..constants import MANAGED_COMMENT, SYSTEMD_NETWORK_DIR, TABLE_NAME_PREFIX
 from ..models import InterfaceInfo, PlannedChange, RoutingTable
 from ..utils import read_file, run_command, write_file_atomic
-from .base import PersistenceBackend
+from .base import PersistenceBackend, group_by_name
 
 logger = logging.getLogger(__name__)
 
@@ -32,21 +32,21 @@ class SystemdNetworkdBackend(PersistenceBackend):
         table_num = {t.name: t.number for t in tables}
 
         written = []
-        for iface in interfaces:
-            table_name = f"{TABLE_NAME_PREFIX}{iface.name}"
+        for name, entries in group_by_name(interfaces):
+            table_name = f"{TABLE_NAME_PREFIX}{name}"
             tnum = table_num.get(table_name)
             if tnum is None:
                 continue
 
-            content = self._generate_network_file(iface, tnum)
-            fpath = os.path.join(SYSTEMD_NETWORK_DIR, f"50-sbr-{iface.name}.network")
+            content = self._generate_network_file(name, entries, tnum)
+            fpath = os.path.join(SYSTEMD_NETWORK_DIR, f"50-sbr-{name}.network")
             write_file_atomic(fpath, content)
             written.append(fpath)
             logger.info("Wrote networkd config: %s", fpath)
 
         # Reload networkd
         if written:
-            run_command("networkctl reload", check=False)
+            run_command("networkctl reload", check=False, timeout=30)
 
         return written
 
@@ -65,7 +65,7 @@ class SystemdNetworkdBackend(PersistenceBackend):
                     logger.info("Removed networkd config: %s", fpath)
 
         if removed:
-            run_command("networkctl reload", check=False)
+            run_command("networkctl reload", check=False, timeout=30)
 
         return removed
 
@@ -75,39 +75,60 @@ class SystemdNetworkdBackend(PersistenceBackend):
             f"Files named 50-sbr-<interface>.network with Route and RoutingPolicyRule sections."
         )
 
-    def _generate_network_file(self, iface: InterfaceInfo, table_number: int) -> str:
-        """Generate a .network file for a single interface."""
-        # Determine priority (use same logic as planner)
-        priority = 100 + (table_number - 100) * 10
+    def _generate_network_file(
+        self,
+        name: str,
+        entries: List[InterfaceInfo],
+        table_number: int,
+    ) -> str:
+        """Generate a .network file for a single interface.
 
+        ``entries`` holds one InterfaceInfo per address on the interface.
+        """
+        # Follows the planner's allocation scheme; clamped so pre-existing
+        # sbr_ tables numbered below 100 don't produce an invalid negative
+        # priority.
+        priority = max(100, 100 + (table_number - 100) * 10)
+
+        ips = ", ".join(e.ip_address for e in entries)
         lines = [
             MANAGED_COMMENT,
-            f"# Source-based routing for {iface.name} ({iface.ip_address})",
+            f"# Source-based routing for {name} ({ips})",
             "",
             "[Match]",
-            f"Name={iface.name}",
-            "",
-            "[Route]",
-            f"Destination={iface.subnet}",
-            f"Table={table_number}",
+            f"Name={name}",
             "",
         ]
 
-        # Only add default route if a gateway is known
-        if iface.gateway is not None:
+        seen_subnets = set()
+        for entry in entries:
+            if entry.subnet in seen_subnets:
+                continue
+            seen_subnets.add(entry.subnet)
             lines.extend([
                 "[Route]",
-                f"Gateway={iface.gateway}",
+                f"Destination={entry.subnet}",
                 f"Table={table_number}",
                 "",
             ])
 
-        lines.extend([
-            "[RoutingPolicyRule]",
-            f"From={iface.ip_address}",
-            f"Table={table_number}",
-            f"Priority={priority}",
-            "",
-        ])
+        # Only add a default route if a gateway is known (one per table)
+        gateway = next((e.gateway for e in entries if e.gateway is not None), None)
+        if gateway is not None:
+            lines.extend([
+                "[Route]",
+                f"Gateway={gateway}",
+                f"Table={table_number}",
+                "",
+            ])
+
+        for entry in entries:
+            lines.extend([
+                "[RoutingPolicyRule]",
+                f"From={entry.ip_address}",
+                f"Table={table_number}",
+                f"Priority={priority}",
+                "",
+            ])
 
         return "\n".join(lines)

--- a/preinstall/sbr-config/sbr_config/persistence_backends/systemd_networkd.py
+++ b/preinstall/sbr-config/sbr_config/persistence_backends/systemd_networkd.py
@@ -9,8 +9,11 @@ from ..constants import (
     MANAGED_COMMENT,
     NETWORKD_DROPIN_NAME,
     NETWORKD_LINKS_STATE_DIR,
+    RULE_PRIORITY_INCREMENT,
+    RULE_PRIORITY_START,
     SYSTEMD_NETWORK_DIR,
     TABLE_NAME_PREFIX,
+    TABLE_NUMBER_START,
 )
 from ..models import InterfaceInfo, PlannedChange, RoutingTable
 from ..utils import read_file, run_command, write_file_atomic
@@ -160,9 +163,13 @@ class SystemdNetworkdBackend(PersistenceBackend):
         that already matches the link.
         """
         # Follows the planner's allocation scheme; clamped so pre-existing
-        # sbr_ tables numbered below 100 don't produce an invalid negative
-        # priority.
-        priority = max(100, 100 + (table_number - 100) * 10)
+        # sbr_ tables numbered below the allocation base don't produce an
+        # invalid priority.
+        priority = max(
+            RULE_PRIORITY_START,
+            RULE_PRIORITY_START
+            + (table_number - TABLE_NUMBER_START) * RULE_PRIORITY_INCREMENT,
+        )
 
         ips = ", ".join(e.ip_address for e in entries)
         lines = [

--- a/preinstall/sbr-config/sbr_config/planner.py
+++ b/preinstall/sbr-config/sbr_config/planner.py
@@ -1,12 +1,13 @@
 """Compute ordered change sets with human-readable explanations."""
 
 import logging
-from typing import Dict, List, Set
+from typing import Dict, List, Optional, Set
 
 from .constants import (
     RESERVED_TABLE_NAMES,
     RESERVED_TABLE_NUMBERS,
     RULE_PRIORITY_INCREMENT,
+    RULE_PRIORITY_MAX,
     RULE_PRIORITY_START,
     TABLE_NAME_PREFIX,
     TABLE_NUMBER_MAX,
@@ -27,6 +28,7 @@ logger = logging.getLogger(__name__)
 def plan_changes(
     state: SystemState,
     validation_results: List[ValidationResult],
+    rule_priority_start: Optional[int] = None,
 ) -> List[PlannedChange]:
     """Generate an ordered list of changes needed to establish correct SBR.
 
@@ -40,10 +42,14 @@ def plan_changes(
     Args:
         state: Current system state.
         validation_results: Results from validator.
+        rule_priority_start: Base priority for new IP rules; defaults to
+                             RULE_PRIORITY_START (10000).
 
     Returns:
         Ordered list of PlannedChange entries.
     """
+    if rule_priority_start is None:
+        rule_priority_start = RULE_PRIORITY_START
     changes: List[PlannedChange] = []
 
     # Collect failed checks by interface
@@ -205,10 +211,19 @@ def plan_changes(
                 and not _has_ip_rule(state, iface, table_name)):
             planned_rules.add((iface.ip_address, table_name))
 
-            # Determine priority: find unused priority slot
-            priority = RULE_PRIORITY_START
+            # Determine priority: find unused priority slot. Never step
+            # past the main table lookup (32766) -- a rule there is dead
+            # configuration, so skip it loudly instead.
+            priority = rule_priority_start
             while priority in used_priorities:
                 priority += RULE_PRIORITY_INCREMENT
+            if priority > RULE_PRIORITY_MAX:
+                logger.error(
+                    "No free rule priority slot below %d for %s "
+                    "(base %d); skipping its IP rule",
+                    RULE_PRIORITY_MAX + 1, iface.name, rule_priority_start,
+                )
+                continue
             used_priorities.add(priority)
 
             rule_cmd = (

--- a/preinstall/sbr-config/sbr_config/planner.py
+++ b/preinstall/sbr-config/sbr_config/planner.py
@@ -77,6 +77,17 @@ def plan_changes(
 
     next_number = TABLE_NUMBER_START
 
+    # An interface can carry multiple IPv4 addresses, so state.interfaces may
+    # hold several entries with the same name (one per address) and validation
+    # failures are merged per name. Track what this plan already covers and
+    # re-verify each phase against the detected state, otherwise a second
+    # address plans a duplicate `ip route add` that fails with EEXIST and
+    # aborts the whole apply.
+    planned_tables: Set[str] = set()
+    planned_routes: Set[tuple] = set()  # (table_name, destination)
+    planned_rules: Set[tuple] = set()   # (ip_address, table_name)
+    used_priorities = {r.priority for r in state.rules}
+
     for iface in state.interfaces:
         if iface.is_loopback or iface.is_default_route_interface or not iface.is_up:
             continue
@@ -88,7 +99,8 @@ def plan_changes(
         table_name = f"{TABLE_NAME_PREFIX}{iface.name}"
 
         # Phase 1: Routing table entry
-        if "routing_table_exists" in iface_fails:
+        if "routing_table_exists" in iface_fails and table_name not in planned_tables:
+            planned_tables.add(table_name)
             # Allocate a table number
             if iface.name not in table_assignments:
                 while (next_number in used_numbers
@@ -119,7 +131,10 @@ def plan_changes(
             ))
 
         # Phase 2: Subnet route
-        if "subnet_route_in_table" in iface_fails:
+        if ("subnet_route_in_table" in iface_fails
+                and (table_name, iface.subnet) not in planned_routes
+                and not _has_subnet_route(state, table_name, iface)):
+            planned_routes.add((table_name, iface.subnet))
             route_cmd = (
                 f"ip route add {iface.subnet} dev {iface.name} "
                 f"src {iface.ip_address} table {table_name}"
@@ -147,7 +162,11 @@ def plan_changes(
             ))
 
         # Phase 3: Default route in custom table (only if gateway exists)
-        if iface.gateway is not None and "default_route_in_table" in iface_fails:
+        if (iface.gateway is not None
+                and "default_route_in_table" in iface_fails
+                and (table_name, "default") not in planned_routes
+                and not _has_default_route(state, table_name, iface)):
+            planned_routes.add((table_name, "default"))
             route_cmd = (
                 f"ip route add default via {iface.gateway} "
                 f"dev {iface.name} table {table_name}"
@@ -175,9 +194,12 @@ def plan_changes(
             ))
 
         # Phase 4: IP rule
-        if "ip_rule_exists" in iface_fails:
+        if ("ip_rule_exists" in iface_fails
+                and (iface.ip_address, table_name) not in planned_rules
+                and not _has_ip_rule(state, iface, table_name)):
+            planned_rules.add((iface.ip_address, table_name))
+
             # Determine priority: find unused priority slot
-            used_priorities = {r.priority for r in state.rules}
             priority = RULE_PRIORITY_START
             while priority in used_priorities:
                 priority += RULE_PRIORITY_INCREMENT
@@ -211,3 +233,35 @@ def plan_changes(
 
     logger.info("Planned %d changes", len(changes))
     return changes
+
+
+# ---------------------------------------------------------------------------
+# State re-checks
+#
+# Validation failures are merged per interface NAME, but an interface can
+# have several addresses (and subnets). These mirror the validator's checks
+# so each planned change is verified against the exact entry it targets.
+# ---------------------------------------------------------------------------
+
+def _has_subnet_route(state: SystemState, table_name: str, iface: InterfaceInfo) -> bool:
+    return any(
+        r.destination == iface.subnet and r.device == iface.name
+        for r in state.routes_by_table.get(table_name, [])
+    )
+
+
+def _has_default_route(state: SystemState, table_name: str, iface: InterfaceInfo) -> bool:
+    return any(
+        r.destination == "default"
+        and r.gateway == iface.gateway
+        and r.device == iface.name
+        for r in state.routes_by_table.get(table_name, [])
+    )
+
+
+def _has_ip_rule(state: SystemState, iface: InterfaceInfo, table_name: str) -> bool:
+    return any(
+        r.selector_from in (iface.ip_address, f"{iface.ip_address}/32")
+        and r.table == table_name
+        for r in state.rules
+    )

--- a/preinstall/sbr-config/sbr_config/planner.py
+++ b/preinstall/sbr-config/sbr_config/planner.py
@@ -64,8 +64,14 @@ def plan_changes(
     sysctl_changes = plan_sysctl_changes(state.sysctl_values, non_default_ifaces)
     changes.extend(sysctl_changes)
 
-    # Allocate table numbers for interfaces that need them
+    # Allocate table numbers for interfaces that need them. Numbers in
+    # active kernel use (routes/rules referencing numeric-only tables,
+    # e.g. cloud-init policy routing) count as used even though they
+    # never appear in rt_tables -- allocating one would alias our named
+    # table onto someone else's, and rollback's flush would then destroy
+    # their routes.
     used_numbers = {rt.number for rt in state.routing_tables}
+    used_numbers.update(getattr(state, "active_table_numbers", []) or [])
     used_names = {rt.name for rt in state.routing_tables}
     table_assignments: Dict[str, int] = {}  # iface_name -> table_number
 

--- a/preinstall/sbr-config/sbr_config/rollback.py
+++ b/preinstall/sbr-config/sbr_config/rollback.py
@@ -14,6 +14,7 @@ from .constants import (
     MANAGED_COMMENT,
     NETPLAN_CONFIG_FILE,
     NETPLAN_DIR,
+    NETWORKD_DROPIN_NAME,
     NM_DISPATCHER_DIR,
     NM_DISPATCHER_SCRIPT,
     RT_TABLES_PATH,
@@ -23,8 +24,12 @@ from .constants import (
 )
 from .exceptions import RollbackError
 from .models import Route, Rule, SystemState
-from .sysctl import remove_sysctl_persistence
-from .utils import read_file, run_command, write_file_atomic
+from .sysctl import (
+    refresh_sysctl_persistence,
+    remove_sysctl_persistence,
+    sysctl_key_to_cmd,
+)
+from .utils import read_file, run_command, strip_managed_lines, write_file_atomic
 
 logger = logging.getLogger(__name__)
 
@@ -32,9 +37,12 @@ NM_DISPATCHER_PATH = os.path.join(NM_DISPATCHER_DIR, NM_DISPATCHER_SCRIPT)
 
 
 def _managed_file_paths() -> List[str]:
-    """All persistence file paths sbr-config manages (existing or not).
+    """All persistence file paths sbr-config manages or may append to.
 
     Fixed paths are always listed; glob-based ones only when present.
+    Includes every file in interfaces.d (not just our sbr-* drop-ins)
+    because sbr-config may append managed lines to a user's drop-in that
+    holds the interface stanza.
     """
     paths = [
         SYSCTL_CONF_PATH,
@@ -42,9 +50,29 @@ def _managed_file_paths() -> List[str]:
         os.path.join(NETPLAN_DIR, NETPLAN_CONFIG_FILE),
         INTERFACES_FILE,
     ]
+    # networkd: current drop-in layout plus the legacy standalone files
+    paths += sorted(glob.glob(
+        os.path.join(SYSTEMD_NETWORK_DIR, "*.network.d", NETWORKD_DROPIN_NAME)
+    ))
     paths += sorted(glob.glob(os.path.join(SYSTEMD_NETWORK_DIR, "50-sbr-*.network")))
-    paths += sorted(glob.glob(os.path.join(INTERFACES_D_DIR, "sbr-*")))
+    paths += sorted(
+        p for p in glob.glob(os.path.join(INTERFACES_D_DIR, "*"))
+        if os.path.isfile(p)
+    )
     return paths
+
+
+def _is_append_style(path: str) -> bool:
+    """Files sbr-config appends to but does not own outright.
+
+    These are never deleted during restore -- managed lines are stripped
+    instead -- and are only rewritten when our marker shows we modified
+    them.
+    """
+    if path == INTERFACES_FILE:
+        return True
+    dirname, basename = os.path.split(path)
+    return dirname == INTERFACES_D_DIR and not basename.startswith("sbr-")
 
 
 def save_state(state: SystemState, backup_dir: str = BACKUP_DIR) -> str:
@@ -358,8 +386,11 @@ def _restore_sysctl(saved: dict) -> None:
     saved_values = saved.get("sysctl_values", {})
     for key, value in saved_values.items():
         if value and value != "unknown":
+            # Slash notation for per-interface keys so dotted interface
+            # names (VLANs) aren't mangled by the sysctl binary.
+            cmd_key = sysctl_key_to_cmd(key)
             try:
-                run_command(f"sysctl -w {key}={value}", check=False)
+                run_command(f"sysctl -w {cmd_key}={value}", check=False)
                 logger.info("Restored sysctl %s = %s", key, value)
             except Exception as e:
                 logger.warning("Failed to restore sysctl %s: %s", key, e)
@@ -377,12 +408,20 @@ def _restore_persistence_files(saved: dict) -> None:
         _remove_persistence_files()
         return
 
-    # Remove managed files that didn't exist at backup time. The main
-    # interfaces file is never deleted -- it's user-owned; content restore
-    # below handles any lines we appended to it.
+    # Remove managed files that didn't exist at backup time. Append-style
+    # files (the main interfaces file and user drop-ins we may have
+    # appended to) are never deleted -- managed lines are stripped instead.
     for path in _managed_file_paths():
-        if snapshot.get(path) is None and path != INTERFACES_FILE:
+        if snapshot.get(path) is not None:
+            continue
+        if _is_append_style(path):
+            current = read_file(path)
+            if current and MANAGED_COMMENT in current:
+                write_file_atomic(path, strip_managed_lines(current))
+                logger.info("Stripped sbr-config lines from %s", path)
+        else:
             _remove_managed_file(path)
+            _cleanup_empty_dropin_dir(path)
 
     # Restore recorded contents
     for path, content in snapshot.items():
@@ -391,13 +430,34 @@ def _restore_persistence_files(saved: dict) -> None:
         current = read_file(path)
         if current == content:
             continue
-        if path == INTERFACES_FILE and (current is None or MANAGED_COMMENT not in current):
-            # Only rewrite the interfaces file if our own lines are in it;
+        if _is_append_style(path) and (current is None or MANAGED_COMMENT not in current):
+            # Only rewrite user-owned files if our own lines are in them;
             # otherwise the difference is someone else's edit.
             continue
         mode = 0o755 if path == NM_DISPATCHER_PATH else None
         write_file_atomic(path, content, mode=mode)
         logger.info("Restored %s from backup", path)
+
+    # A backup taken under <=1.2.0 restores a sysctl.d file with
+    # per-interface keys, reintroducing boot errors for late-created
+    # interfaces. Heal it to the current format right away.
+    try:
+        if refresh_sysctl_persistence():
+            logger.info(
+                "Healed restored %s to the current format", SYSCTL_CONF_PATH
+            )
+    except Exception as e:
+        logger.warning("Could not heal restored sysctl persistence: %s", e)
+
+
+def _cleanup_empty_dropin_dir(path: str) -> None:
+    """Remove a now-empty *.network.d drop-in directory."""
+    parent = os.path.dirname(path)
+    if parent.endswith(".network.d") and os.path.isdir(parent):
+        try:
+            os.rmdir(parent)
+        except OSError:
+            pass  # not empty or already gone
 
 
 def _remove_persistence_files() -> None:
@@ -411,17 +471,36 @@ def _remove_persistence_files() -> None:
     # Netplan config
     _remove_managed_file(os.path.join(NETPLAN_DIR, NETPLAN_CONFIG_FILE))
 
-    # systemd-networkd drop-in files
+    # systemd-networkd: drop-ins plus legacy standalone files (<=1.2.x)
+    for path in glob.glob(
+        os.path.join(SYSTEMD_NETWORK_DIR, "*.network.d", NETWORKD_DROPIN_NAME)
+    ):
+        _remove_managed_file(path)
+        _cleanup_empty_dropin_dir(path)
     if os.path.isdir(SYSTEMD_NETWORK_DIR):
         for fname in os.listdir(SYSTEMD_NETWORK_DIR):
-            if fname.startswith("50-sbr-"):
+            if fname.startswith("50-sbr-") and fname.endswith(".network"):
                 _remove_managed_file(os.path.join(SYSTEMD_NETWORK_DIR, fname))
 
-    # ifupdown files in interfaces.d
+    # ifupdown: strip managed lines from the main interfaces file
+    main_content = read_file(INTERFACES_FILE)
+    if main_content and MANAGED_COMMENT in main_content:
+        write_file_atomic(INTERFACES_FILE, strip_managed_lines(main_content))
+        logger.info("Stripped sbr-config lines from %s", INTERFACES_FILE)
+
+    # ifupdown: our drop-ins removed, managed lines stripped from user files
     if os.path.isdir(INTERFACES_D_DIR):
         for fname in os.listdir(INTERFACES_D_DIR):
+            fpath = os.path.join(INTERFACES_D_DIR, fname)
+            if not os.path.isfile(fpath):
+                continue
             if fname.startswith("sbr-"):
-                _remove_managed_file(os.path.join(INTERFACES_D_DIR, fname))
+                _remove_managed_file(fpath)
+            else:
+                content = read_file(fpath)
+                if content and MANAGED_COMMENT in content:
+                    write_file_atomic(fpath, strip_managed_lines(content))
+                    logger.info("Stripped sbr-config lines from %s", fpath)
 
     # Sysctl persistence
     remove_sysctl_persistence()

--- a/preinstall/sbr-config/sbr_config/rollback.py
+++ b/preinstall/sbr-config/sbr_config/rollback.py
@@ -1,18 +1,50 @@
 """Save and restore system state for rollback capability."""
 
+import glob
 import json
 import logging
 import os
 from datetime import datetime, timezone
 from typing import List, Optional
 
-from .constants import BACKUP_DIR, MANAGED_COMMENT, RT_TABLES_PATH, TABLE_NAME_PREFIX
+from .constants import (
+    BACKUP_DIR,
+    INTERFACES_D_DIR,
+    INTERFACES_FILE,
+    MANAGED_COMMENT,
+    NETPLAN_CONFIG_FILE,
+    NETPLAN_DIR,
+    NM_DISPATCHER_DIR,
+    NM_DISPATCHER_SCRIPT,
+    RT_TABLES_PATH,
+    SYSCTL_CONF_PATH,
+    SYSTEMD_NETWORK_DIR,
+    TABLE_NAME_PREFIX,
+)
 from .exceptions import RollbackError
-from .models import SystemState
+from .models import Route, Rule, SystemState
 from .sysctl import remove_sysctl_persistence
 from .utils import read_file, run_command, write_file_atomic
 
 logger = logging.getLogger(__name__)
+
+NM_DISPATCHER_PATH = os.path.join(NM_DISPATCHER_DIR, NM_DISPATCHER_SCRIPT)
+
+
+def _managed_file_paths() -> List[str]:
+    """All persistence file paths sbr-config manages (existing or not).
+
+    Fixed paths are always listed; glob-based ones only when present.
+    """
+    paths = [
+        SYSCTL_CONF_PATH,
+        NM_DISPATCHER_PATH,
+        os.path.join(NETPLAN_DIR, NETPLAN_CONFIG_FILE),
+        INTERFACES_FILE,
+    ]
+    paths += sorted(glob.glob(os.path.join(SYSTEMD_NETWORK_DIR, "50-sbr-*.network")))
+    paths += sorted(glob.glob(os.path.join(INTERFACES_D_DIR, "sbr-*")))
+    return paths
 
 
 def save_state(state: SystemState, backup_dir: str = BACKUP_DIR) -> str:
@@ -30,11 +62,25 @@ def save_state(state: SystemState, backup_dir: str = BACKUP_DIR) -> str:
     timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
     filepath = os.path.join(backup_dir, f"state_{timestamp}.json")
 
+    # Never overwrite an existing backup -- add a counter suffix if two
+    # saves land in the same second, so every backup stays referenceable.
+    suffix = 1
+    while os.path.exists(filepath):
+        suffix += 1
+        filepath = os.path.join(backup_dir, f"state_{timestamp}_{suffix}.json")
+
     data = state.to_dict()
 
     # Add raw file contents for exact restoration
     data["_raw_files"] = {
         RT_TABLES_PATH: state.rt_tables_file_content,
+    }
+
+    # Snapshot every managed persistence file (content, or None if absent)
+    # so rollback can restore the box to this exact configuration instead
+    # of stripping all SBR persistence.
+    data["_persistence_files"] = {
+        path: read_file(path) for path in _managed_file_paths()
     }
 
     with open(filepath, "w") as f:
@@ -48,6 +94,8 @@ def save_state(state: SystemState, backup_dir: str = BACKUP_DIR) -> str:
         os.unlink(latest)
     os.symlink(filepath, latest)
 
+    prune_backups(backup_dir)
+
     logger.info("Saved state backup to %s", filepath)
     return filepath
 
@@ -56,7 +104,11 @@ def rollback(
     backup_path: Optional[str] = None,
     backup_dir: str = BACKUP_DIR,
 ) -> None:
-    """Restore system to a previously saved state.
+    """Restore the system to a previously saved state.
+
+    The target is the running configuration captured in the backup: SBR
+    rules, routes, rt_tables entries, and persistence files that existed
+    at backup time are put back exactly; anything added since is removed.
 
     Args:
         backup_path: Specific backup file to restore from.
@@ -83,20 +135,23 @@ def rollback(
     except (json.JSONDecodeError, IOError) as e:
         raise RollbackError(f"Failed to read backup file: {e}") from e
 
-    # Step 1: Remove IP rules that were added by sbr-config
+    # Step 1: Remove current SBR rules and flush SBR tables so the restore
+    # starts from a clean slate (uses the CURRENT rt_tables to find them)
     _remove_sbr_rules()
-
-    # Step 2: Flush custom SBR routing tables
     _flush_sbr_tables()
 
-    # Step 3: Restore /etc/iproute2/rt_tables
+    # Step 2: Restore /etc/iproute2/rt_tables
     _restore_rt_tables(saved)
+
+    # Step 3: Re-add the SBR routes and rules that were running at backup time
+    _restore_sbr_routes(saved)
+    _restore_sbr_rules(saved)
 
     # Step 4: Restore sysctl settings
     _restore_sysctl(saved)
 
-    # Step 5: Remove persistence configs
-    _remove_persistence_files()
+    # Step 5: Restore persistence configs to their backed-up contents
+    _restore_persistence_files(saved)
 
     logger.info("Rollback complete")
 
@@ -239,8 +294,67 @@ def _restore_rt_tables(saved: dict) -> None:
         logger.info("Removed sbr_ entries from %s", RT_TABLES_PATH)
 
 
+def _restore_sbr_routes(saved: dict) -> None:
+    """Re-add routes the backup recorded in sbr_ tables.
+
+    Restores the previous running config: routes that existed in custom
+    SBR tables at backup time come back, whether sbr-config created them
+    or not. Subnet/link routes go first so default routes can resolve
+    their gateway.
+    """
+    routes_by_table = saved.get("routes_by_table") or {}
+    for table_name, route_dicts in routes_by_table.items():
+        if not table_name.startswith(TABLE_NAME_PREFIX):
+            continue
+        ordered = sorted(
+            route_dicts, key=lambda rd: rd.get("destination") == "default"
+        )
+        for rd in ordered:
+            route = Route(
+                destination=rd.get("destination", ""),
+                gateway=rd.get("gateway"),
+                device=rd.get("device", ""),
+                source=rd.get("source"),
+                table=table_name,
+                metric=rd.get("metric"),
+                scope=rd.get("scope"),
+            )
+            if not route.destination or not route.device:
+                continue
+            try:
+                run_command(f"ip route replace {route.to_args()}", check=False)
+                logger.info("Restored route: %s", route.to_args())
+            except Exception as e:
+                logger.warning("Failed to restore route '%s': %s", route.to_args(), e)
+
+
+def _restore_sbr_rules(saved: dict) -> None:
+    """Re-add IP rules the backup recorded pointing at sbr_ tables."""
+    for rd in saved.get("rules") or []:
+        table = rd.get("table")
+        if not table or not str(table).startswith(TABLE_NAME_PREFIX):
+            continue
+        rule = Rule(
+            priority=rd.get("priority", 0),
+            selector_from=rd.get("selector_from"),
+            selector_to=rd.get("selector_to"),
+            table=table,
+            iif=rd.get("iif"),
+            fwmark=rd.get("fwmark"),
+        )
+        try:
+            run_command(f"ip rule add {rule.to_args()}", check=False)
+            logger.info("Restored rule: %s", rule.to_args())
+        except Exception as e:
+            logger.warning("Failed to restore rule '%s': %s", rule.to_args(), e)
+
+
 def _restore_sysctl(saved: dict) -> None:
-    """Restore sysctl values from backup."""
+    """Restore sysctl values from backup.
+
+    The sysctl persistence file is handled by the persistence snapshot
+    restore, not here.
+    """
     saved_values = saved.get("sysctl_values", {})
     for key, value in saved_values.items():
         if value and value != "unknown":
@@ -250,42 +364,64 @@ def _restore_sysctl(saved: dict) -> None:
             except Exception as e:
                 logger.warning("Failed to restore sysctl %s: %s", key, e)
 
-    # Remove persistence file
-    remove_sysctl_persistence()
+
+def _restore_persistence_files(saved: dict) -> None:
+    """Restore persistence files to their backed-up contents.
+
+    Files that existed at backup time get their saved content back; managed
+    files created since are removed. Backups from before this snapshot was
+    recorded fall back to removing all managed persistence files.
+    """
+    snapshot = saved.get("_persistence_files")
+    if snapshot is None:
+        _remove_persistence_files()
+        return
+
+    # Remove managed files that didn't exist at backup time. The main
+    # interfaces file is never deleted -- it's user-owned; content restore
+    # below handles any lines we appended to it.
+    for path in _managed_file_paths():
+        if snapshot.get(path) is None and path != INTERFACES_FILE:
+            _remove_managed_file(path)
+
+    # Restore recorded contents
+    for path, content in snapshot.items():
+        if content is None:
+            continue
+        current = read_file(path)
+        if current == content:
+            continue
+        if path == INTERFACES_FILE and (current is None or MANAGED_COMMENT not in current):
+            # Only rewrite the interfaces file if our own lines are in it;
+            # otherwise the difference is someone else's edit.
+            continue
+        mode = 0o755 if path == NM_DISPATCHER_PATH else None
+        write_file_atomic(path, content, mode=mode)
+        logger.info("Restored %s from backup", path)
 
 
 def _remove_persistence_files() -> None:
-    """Remove all persistence files created by sbr-config."""
-    from .constants import (
-        NM_DISPATCHER_DIR,
-        NM_DISPATCHER_SCRIPT,
-        NETPLAN_CONFIG_FILE,
-        NETPLAN_DIR,
-        SYSTEMD_NETWORK_DIR,
-    )
+    """Remove all persistence files created by sbr-config.
 
+    Fallback for backups saved before persistence snapshots existed.
+    """
     # NetworkManager dispatcher script
-    nm_path = os.path.join(NM_DISPATCHER_DIR, NM_DISPATCHER_SCRIPT)
-    _remove_managed_file(nm_path)
+    _remove_managed_file(NM_DISPATCHER_PATH)
 
     # Netplan config
-    netplan_path = os.path.join(NETPLAN_DIR, NETPLAN_CONFIG_FILE)
-    _remove_managed_file(netplan_path)
+    _remove_managed_file(os.path.join(NETPLAN_DIR, NETPLAN_CONFIG_FILE))
 
     # systemd-networkd drop-in files
     if os.path.isdir(SYSTEMD_NETWORK_DIR):
         for fname in os.listdir(SYSTEMD_NETWORK_DIR):
             if fname.startswith("50-sbr-"):
-                fpath = os.path.join(SYSTEMD_NETWORK_DIR, fname)
-                _remove_managed_file(fpath)
+                _remove_managed_file(os.path.join(SYSTEMD_NETWORK_DIR, fname))
 
     # ifupdown files in interfaces.d
-    from .constants import INTERFACES_D_DIR
     if os.path.isdir(INTERFACES_D_DIR):
         for fname in os.listdir(INTERFACES_D_DIR):
             if fname.startswith("sbr-"):
-                fpath = os.path.join(INTERFACES_D_DIR, fname)
-                _remove_managed_file(fpath)
+                _remove_managed_file(os.path.join(INTERFACES_D_DIR, fname))
 
     # Sysctl persistence
     remove_sysctl_persistence()

--- a/preinstall/sbr-config/sbr_config/sysctl.py
+++ b/preinstall/sbr-config/sbr_config/sysctl.py
@@ -167,20 +167,22 @@ def apply_sysctl(key: str, value: str) -> None:
 
 
 def write_sysctl_persistence(
-    changes: List[PlannedChange],
+    interface_names: List[str],
 ) -> str:
     """Write /etc/sysctl.d/90-sbr-config.conf for persistence.
 
+    The file contains the COMPLETE set of required SBR sysctl settings,
+    not just the ones changed in this run. A setting that already happened
+    to be correct at runtime (e.g. set manually with `sysctl -w`) still
+    needs to be persisted or it reverts on reboot.
+
     Args:
-        changes: List of sysctl PlannedChange entries.
+        interface_names: Non-default interface names needing per-interface
+                         rp_filter settings.
 
     Returns:
         Path to the written config file.
     """
-    sysctl_changes = [c for c in changes if c.change_type == ChangeType.SET_SYSCTL]
-    if not sysctl_changes:
-        return ""
-
     lines = [
         MANAGED_COMMENT,
         "# Sysctl settings for source-based routing",
@@ -190,11 +192,15 @@ def write_sysctl_persistence(
         "",
     ]
 
-    for change in sysctl_changes:
-        # Extract key=value from the command "sysctl -w key=value"
-        kv = change.command.replace("sysctl -w ", "")
-        lines.append(f"# {change.description}")
-        lines.append(kv)
+    for key, spec in SYSCTL_SETTINGS.items():
+        lines.append(f"# {spec['description']}")
+        lines.append(f"{key} = {spec['required']}")
+        lines.append("")
+
+    for iface in interface_names:
+        key = SYSCTL_PER_IFACE_TEMPLATE.format(iface=iface)
+        lines.append(f"# Loose-mode rp_filter for {iface}")
+        lines.append(f"{key} = 2")
         lines.append("")
 
     content = "\n".join(lines) + "\n"

--- a/preinstall/sbr-config/sbr_config/sysctl.py
+++ b/preinstall/sbr-config/sbr_config/sysctl.py
@@ -2,7 +2,8 @@
 
 import logging
 import os
-from typing import Dict, List, Tuple
+import re
+from typing import Dict, List, Optional, Tuple
 
 from .constants import (
     MANAGED_COMMENT,
@@ -17,22 +18,52 @@ from .utils import read_file, run_command, write_file_atomic
 logger = logging.getLogger(__name__)
 
 
-def read_sysctl(key: str) -> str:
-    """Read a sysctl value from /proc/sys.
-
-    Args:
-        key: Sysctl key in dotted notation (e.g., net.ipv4.conf.all.rp_filter).
-
-    Returns:
-        The current value as a string, or "unknown" if unreadable.
-    """
-    proc_path = "/proc/sys/" + key.replace(".", "/")
+def _read_proc_value(proc_path: str) -> str:
+    """Read a /proc/sys value, returning 'unknown' if unreadable."""
     try:
         with open(proc_path, "r") as f:
             return f.read().strip()
     except (FileNotFoundError, PermissionError) as e:
-        logger.warning("Cannot read sysctl %s: %s", key, e)
+        logger.warning("Cannot read %s: %s", proc_path, e)
         return "unknown"
+
+
+def read_sysctl(key: str) -> str:
+    """Read a global sysctl value from /proc/sys.
+
+    Args:
+        key: Sysctl key in dotted notation (e.g., net.ipv4.conf.all.rp_filter).
+             Only safe for keys whose segments contain no dots -- for
+             per-interface keys use sysctl_key_to_cmd/_read_proc_value with
+             an explicit path, since interface names may contain dots
+             (VLANs like eth0.100).
+
+    Returns:
+        The current value as a string, or "unknown" if unreadable.
+    """
+    return _read_proc_value("/proc/sys/" + key.replace(".", "/"))
+
+
+def sysctl_key_to_cmd(key: str) -> str:
+    """Return a sysctl(8)-safe form of a dotted key.
+
+    Per-interface rp_filter keys are rewritten to slash notation
+    (net/ipv4/conf/<iface>/rp_filter) so interface names containing dots
+    (VLANs like eth0.100) aren't split into bogus path components by the
+    sysctl binary. Global keys pass through unchanged.
+    """
+    m = re.match(r"^net\.ipv4\.conf\.(.+)\.rp_filter$", key)
+    if m and m.group(1) not in ("all", "default"):
+        return "net/ipv4/conf/{}/rp_filter".format(m.group(1))
+    return key
+
+
+def _rp_filter_effectively_loose(current: str, all_rp: str) -> bool:
+    """The kernel evaluates max(conf.all, conf.iface) for rp_filter, so
+    loose mode is effective when EITHER value is 2. Single source of truth
+    for both validation and planning -- they must stay in agreement.
+    """
+    return current == "2" or all_rp == "2"
 
 
 def read_all_sysctl_values(interface_names: List[str]) -> Dict[str, str]:
@@ -50,10 +81,14 @@ def read_all_sysctl_values(interface_names: List[str]) -> Dict[str, str]:
     for key in SYSCTL_SETTINGS:
         values[key] = read_sysctl(key)
 
-    # Per-interface rp_filter
+    # Per-interface rp_filter. Read via an explicit /proc path -- the
+    # dotted-key path building in read_sysctl would mangle interface
+    # names that contain dots (VLANs).
     for iface in interface_names:
         key = SYSCTL_PER_IFACE_TEMPLATE.format(iface=iface)
-        values[key] = read_sysctl(key)
+        values[key] = _read_proc_value(
+            "/proc/sys/net/ipv4/conf/{}/rp_filter".format(iface)
+        )
 
     return values
 
@@ -95,7 +130,7 @@ def validate_sysctl(
         key = SYSCTL_PER_IFACE_TEMPLATE.format(iface=iface)
         current = current_values.get(key, "unknown")
         required = "2"
-        is_correct = (current == required) or (all_rp == required)
+        is_correct = _rp_filter_effectively_loose(current, all_rp)
         results.append(ValidationResult(
             interface_name=iface,
             check_name=f"sysctl {key}",
@@ -151,7 +186,10 @@ def plan_sysctl_changes(
         key = SYSCTL_PER_IFACE_TEMPLATE.format(iface=iface)
         current = current_values.get(key, "unknown")
         required = "2"
-        if current != required and all_rp != required:
+        if not _rp_filter_effectively_loose(current, all_rp):
+            # Slash notation keeps dotted interface names (VLANs) intact
+            # when the sysctl binary parses the key.
+            cmd_key = sysctl_key_to_cmd(key)
             changes.append(PlannedChange(
                 change_type=ChangeType.SET_SYSCTL,
                 description=f"Set {key} = {required}",
@@ -160,9 +198,9 @@ def plan_sysctl_changes(
                     f"so that packets arriving on {iface} are not dropped by the "
                     f"reverse path filter when the main table doesn't have a matching route."
                 ),
-                command=f"sysctl -w {key}={required}",
+                command=f"sysctl -w {cmd_key}={required}",
                 interface=iface,
-                rollback_command=f"sysctl -w {key}={current}" if current != "unknown" else None,
+                rollback_command=f"sysctl -w {cmd_key}={current}" if current != "unknown" else None,
             ))
 
     return changes
@@ -199,6 +237,19 @@ def write_sysctl_persistence() -> str:
     Returns:
         Path to the written config file.
     """
+    write_file_atomic(SYSCTL_CONF_PATH, _sysctl_persistence_content())
+    logger.info("Wrote sysctl persistence config to %s", SYSCTL_CONF_PATH)
+    return SYSCTL_CONF_PATH
+
+
+def _sysctl_persistence_content() -> str:
+    """Build the exact desired content of the sysctl.d file.
+
+    Deterministic on purpose: staleness detection compares the on-disk
+    file against this output, which heals any drift (per-interface keys
+    from <=1.2.0, delta-style files from 1.1.x, future format changes)
+    without format-specific sniffing.
+    """
     lines = [
         MANAGED_COMMENT,
         "# Sysctl settings for source-based routing",
@@ -218,35 +269,43 @@ def write_sysctl_persistence() -> str:
         lines.append(f"{key} = {spec['required']}")
         lines.append("")
 
-    content = "\n".join(lines) + "\n"
-    write_file_atomic(SYSCTL_CONF_PATH, content)
-    logger.info("Wrote sysctl persistence config to %s", SYSCTL_CONF_PATH)
-    return SYSCTL_CONF_PATH
+    return "\n".join(lines) + "\n"
 
 
-def refresh_sysctl_persistence_if_stale() -> bool:
-    """Rewrite the sysctl.d file if it contains per-interface keys.
+def refresh_sysctl_persistence(ensure: bool = False) -> Optional[str]:
+    """Bring the managed sysctl.d file in line with the desired content.
 
-    Versions up to 1.2.0 persisted net.ipv4.conf.<iface>.rp_filter entries,
-    which fail at boot for interfaces created by late driver load (ib*) and
-    on machines cloned from images with different NICs. Called on otherwise
-    clean --configure runs so affected systems self-heal.
+    Staleness is "managed file differs from what write_sysctl_persistence
+    would write" -- covering per-interface keys from <=1.2.0 (which fail
+    at boot for interfaces created by late driver load, e.g. ib*),
+    delta-style files from 1.1.x, and any future format drift. A file
+    without our marker is never touched.
+
+    Args:
+        ensure: Also create the file when it doesn't exist (used on clean
+                --configure runs where SBR is active but persistence is
+                missing, so sysctls don't silently revert on reboot).
 
     Returns:
-        True if a stale file was rewritten.
+        "created", "rewritten", or None if nothing was done.
     """
-    import re
-    content = read_file(SYSCTL_CONF_PATH)
-    if not content or MANAGED_COMMENT not in content:
-        return False
-    if not re.search(r"^net\.ipv4\.conf\.(?!all\.|default\.)\S+", content, re.MULTILINE):
-        return False
+    current = read_file(SYSCTL_CONF_PATH)
+    if current is None:
+        if not ensure:
+            return None
+        write_sysctl_persistence()
+        return "created"
+    if MANAGED_COMMENT not in current:
+        logger.warning(
+            "%s exists but is not managed by sbr-config; leaving it alone",
+            SYSCTL_CONF_PATH,
+        )
+        return None
+    if current == _sysctl_persistence_content():
+        return None
     write_sysctl_persistence()
-    logger.info(
-        "Rewrote %s: removed per-interface keys that fail at boot for "
-        "late-created interfaces", SYSCTL_CONF_PATH,
-    )
-    return True
+    logger.info("Rewrote stale %s (old or drifted format)", SYSCTL_CONF_PATH)
+    return "rewritten"
 
 
 def remove_sysctl_persistence() -> bool:

--- a/preinstall/sbr-config/sbr_config/sysctl.py
+++ b/preinstall/sbr-config/sbr_config/sysctl.py
@@ -85,22 +85,31 @@ def validate_sysctl(
             fix_description=spec["reason"] if current != spec["required"] else "",
         ))
 
-    # Check per-interface rp_filter
+    # Check per-interface rp_filter. The kernel uses max(all, iface), so
+    # loose mode is effective when EITHER is 2 -- interfaces created after
+    # boot inherit conf.default and conf.all=2 covers the rest. Requiring
+    # iface==2 outright would false-fail after every reboot on interfaces
+    # created before sysctl.d is applied.
+    all_rp = current_values.get("net.ipv4.conf.all.rp_filter", "unknown")
     for iface in interface_names:
         key = SYSCTL_PER_IFACE_TEMPLATE.format(iface=iface)
         current = current_values.get(key, "unknown")
         required = "2"
+        is_correct = (current == required) or (all_rp == required)
         results.append(ValidationResult(
             interface_name=iface,
             check_name=f"sysctl {key}",
-            is_correct=(current == required),
-            current_value=f"{current} ({_describe_rp_filter(current)})",
-            expected_value=f"{required} (loose mode)",
+            is_correct=is_correct,
+            current_value=(
+                f"{current} ({_describe_rp_filter(current)})"
+                + (" -- loose via conf.all" if is_correct and current != required else "")
+            ),
+            expected_value=f"{required} (loose mode, directly or via conf.all)",
             fix_description=(
-                f"Per-interface rp_filter for {iface} must be set to loose mode (2). "
-                f"The kernel uses max(all, iface) so both the global and per-interface "
-                f"settings must be 2 for loose mode to take effect."
-            ) if current != required else "",
+                f"rp_filter must be loose (2) in effect for {iface}. The kernel "
+                f"uses max(all, {iface}), so either the per-interface or the "
+                f"global 'all' setting must be 2."
+            ) if not is_correct else "",
         ))
 
     return results
@@ -133,12 +142,16 @@ def plan_sysctl_changes(
                 rollback_command=f"sysctl -w {key}={current}" if current != "unknown" else None,
             ))
 
-    # Per-interface rp_filter
+    # Per-interface rp_filter: only needed when neither the interface nor
+    # conf.all is already loose (kernel uses max of the two). Runtime-only --
+    # these keys are deliberately never persisted to sysctl.d (see
+    # write_sysctl_persistence).
+    all_rp = current_values.get("net.ipv4.conf.all.rp_filter", "unknown")
     for iface in interface_names:
         key = SYSCTL_PER_IFACE_TEMPLATE.format(iface=iface)
         current = current_values.get(key, "unknown")
         required = "2"
-        if current != required:
+        if current != required and all_rp != required:
             changes.append(PlannedChange(
                 change_type=ChangeType.SET_SYSCTL,
                 description=f"Set {key} = {required}",
@@ -166,19 +179,22 @@ def apply_sysctl(key: str, value: str) -> None:
     logger.info("Set sysctl %s = %s", key, value)
 
 
-def write_sysctl_persistence(
-    interface_names: List[str],
-) -> str:
+def write_sysctl_persistence() -> str:
     """Write /etc/sysctl.d/90-sbr-config.conf for persistence.
 
-    The file contains the COMPLETE set of required SBR sysctl settings,
-    not just the ones changed in this run. A setting that already happened
-    to be correct at runtime (e.g. set manually with `sysctl -w`) still
-    needs to be persisted or it reverts on reboot.
+    The file contains the COMPLETE set of required global SBR sysctl
+    settings, not just the ones changed in this run. A setting that
+    already happened to be correct at runtime (e.g. set manually with
+    `sysctl -w`) still needs to be persisted or it reverts on reboot.
 
-    Args:
-        interface_names: Non-default interface names needing per-interface
-                         rp_filter settings.
+    Per-interface keys (net.ipv4.conf.<iface>.rp_filter) are deliberately
+    NOT written here. sysctl.d is applied early at boot, before late-binding
+    drivers (notably Mellanox/IPoIB ib*) create their interfaces, so those
+    keys fail with "No such file or directory" on every boot -- and always
+    fail on machines cloned from an image that had different NICs. They are
+    also unnecessary: conf.default.rp_filter=2 is inherited by interfaces
+    created after it is set, and the kernel evaluates max(all, iface), so
+    conf.all.rp_filter=2 makes loose mode effective regardless.
 
     Returns:
         Path to the written config file.
@@ -189,6 +205,11 @@ def write_sysctl_persistence(
         "#",
         "# These settings ensure multi-NIC systems correctly handle",
         "# reverse path filtering and ARP for source-based routing.",
+        "#",
+        "# Per-interface keys are intentionally absent: they break at boot",
+        "# for interfaces that don't exist yet (e.g. ib* created by late",
+        "# driver load). conf.default covers new interfaces and the kernel",
+        "# uses max(all, iface) for rp_filter, so 'all' = 2 is sufficient.",
         "",
     ]
 
@@ -197,16 +218,35 @@ def write_sysctl_persistence(
         lines.append(f"{key} = {spec['required']}")
         lines.append("")
 
-    for iface in interface_names:
-        key = SYSCTL_PER_IFACE_TEMPLATE.format(iface=iface)
-        lines.append(f"# Loose-mode rp_filter for {iface}")
-        lines.append(f"{key} = 2")
-        lines.append("")
-
     content = "\n".join(lines) + "\n"
     write_file_atomic(SYSCTL_CONF_PATH, content)
     logger.info("Wrote sysctl persistence config to %s", SYSCTL_CONF_PATH)
     return SYSCTL_CONF_PATH
+
+
+def refresh_sysctl_persistence_if_stale() -> bool:
+    """Rewrite the sysctl.d file if it contains per-interface keys.
+
+    Versions up to 1.2.0 persisted net.ipv4.conf.<iface>.rp_filter entries,
+    which fail at boot for interfaces created by late driver load (ib*) and
+    on machines cloned from images with different NICs. Called on otherwise
+    clean --configure runs so affected systems self-heal.
+
+    Returns:
+        True if a stale file was rewritten.
+    """
+    import re
+    content = read_file(SYSCTL_CONF_PATH)
+    if not content or MANAGED_COMMENT not in content:
+        return False
+    if not re.search(r"^net\.ipv4\.conf\.(?!all\.|default\.)\S+", content, re.MULTILINE):
+        return False
+    write_sysctl_persistence()
+    logger.info(
+        "Rewrote %s: removed per-interface keys that fail at boot for "
+        "late-created interfaces", SYSCTL_CONF_PATH,
+    )
+    return True
 
 
 def remove_sysctl_persistence() -> bool:

--- a/preinstall/sbr-config/sbr_config/utils.py
+++ b/preinstall/sbr-config/sbr_config/utils.py
@@ -69,6 +69,14 @@ def write_file_atomic(path: str, content: str, mode: Optional[int] = None) -> No
     """
     tmp_path = path + ".sbr-config.tmp"
     try:
+        parent = os.path.dirname(path)
+        if parent and not os.path.isdir(parent):
+            os.makedirs(parent, 0o755)
+            # makedirs honors the umask; pin the mode so non-root tools
+            # (e.g. `ip` resolving rt_tables names) can still read the dir
+            os.chmod(parent, 0o755)
+            logger.info("Created directory %s", parent)
+
         # Determine permissions to use
         if mode is not None:
             file_mode = mode
@@ -159,18 +167,18 @@ class FileLock:
         except OSError:
             self._fd.close()
             raise LockError(
-                "Another sbr-config instance is running. "
-                f"If this is wrong, remove {self.path}"
+                "Another sbr-config instance is running "
+                f"(lock file: {self.path})"
             )
         self._fd.write(str(os.getpid()))
         self._fd.flush()
         return self
 
     def __exit__(self, *args):
+        # The lock file is deliberately left in place: unlinking it opens
+        # a race where two later instances can each flock a different
+        # inode at this path and both "hold" the lock. A stale file never
+        # blocks anything -- flock is released when the process exits.
         if self._fd:
             fcntl.flock(self._fd, fcntl.LOCK_UN)
             self._fd.close()
-            try:
-                os.unlink(self.path)
-            except FileNotFoundError:
-                pass

--- a/preinstall/sbr-config/sbr_config/utils.py
+++ b/preinstall/sbr-config/sbr_config/utils.py
@@ -7,7 +7,7 @@ import platform
 import subprocess
 from typing import Optional
 
-from .constants import LOCK_FILE
+from .constants import LOCK_FILE, MANAGED_COMMENT
 from .exceptions import ConfigurationError, LockError, PrivilegeError
 
 logger = logging.getLogger(__name__)
@@ -107,6 +107,30 @@ def read_file(path: str) -> Optional[str]:
     except PermissionError:
         logger.warning("Permission denied reading %s", path)
         return None
+
+
+def strip_managed_lines(content: str) -> str:
+    """Remove managed blocks sbr-config inserted into a shared config file.
+
+    A block is a MANAGED_COMMENT marker line followed by indented
+    post-up/pre-down lines (the ifupdown insertion format). Everything
+    else is preserved verbatim.
+    """
+    lines = content.splitlines()
+    new_lines = []
+    in_managed_block = False
+
+    for line in lines:
+        if MANAGED_COMMENT in line:
+            in_managed_block = True
+            continue
+        if in_managed_block:
+            if line.strip().startswith(("post-up", "pre-down")):
+                continue
+            in_managed_block = False
+        new_lines.append(line)
+
+    return "\n".join(new_lines)
 
 
 def check_root() -> None:


### PR DESCRIPTION
Syncs `preinstall/sbr-config/` to [SBR-Config v1.2.0](https://github.com/WekaJosh/SBR-Config/releases/tag/v1.2.0), a bug-fix release from a full-project review.

## Highlights

- **Multi-IP interfaces no longer break `--configure`.** Interfaces with several IPv4 addresses previously planned duplicate `ip route add` commands; the second failed with EEXIST and aborted the whole apply. Persistence backends also mishandled these (networkd wrote one file per IP with the last overwriting the rest, netplan emitted invalid duplicate YAML keys, the NM dispatcher generated unreachable case branches). All backends now emit one config per interface covering every address.
- **Rollback is a true snapshot restore.** Backups now capture every managed persistence file alongside rt_tables. Rollback restores the running configuration from backup time: SBR rules, routes, rt_tables entries, sysctl values, and persistence file contents all return to their backed-up state, and anything added since is removed. Legacy backups fall back to the previous behavior.
- **Sysctl persistence writes the complete required set**, not just the current run's delta, so settings that were already correct at runtime survive reboot.
- **ifupdown persistence is idempotent** across repeat runs (no more stacked duplicate post-up/pre-down blocks).
- Assorted smaller fixes: rule priority allocation, lock-file race, `netplan apply` timeout, relative log paths, strict-umask directory creation, missing `/etc/iproute2` auto-created.

Mirror was verified to be an exact copy of upstream v1.1.0 before syncing, so no local changes were overwritten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)